### PR TITLE
fix readme error, update mixed reality file save location

### DIFF
--- a/HoloLensCommander/HoloLensCommander/MainWindowViewModel.cs
+++ b/HoloLensCommander/HoloLensCommander/MainWindowViewModel.cs
@@ -31,7 +31,7 @@ namespace HoloLensCommander
         /// <summary>
         /// Name of the folder which will contain mixed reality files from the registered HoloLens devices.
         /// </summary>
-        private static readonly string MixedRealityFilesFolderName = "HoloLensManager";
+        private static readonly string MixedRealityFilesFolderName = "HoloLensCommander";
 
         /// <summary>
         /// Dispatcher used to ensure notifications happen on the correct thread.

--- a/HoloLensCommander/README.md
+++ b/HoloLensCommander/README.md
@@ -87,7 +87,7 @@ Stops the Mixed Reality Capture video recording.
 
 ##### Save
 
-Files created by the Start and Stop controls, along with any other Mixed Reality Capture files created on the HoloLens (via the Windows Device Portal or a Cortana voice command) will be downloaded to the Photos Library on the PC. Files will be saved to HoloLensManage\<HoloLens address|name>.
+Files created by the Start and Stop controls, along with any other Mixed Reality Capture files created on the HoloLens (via the Windows Device Portal or a Cortana voice command) will be downloaded to the Pictures Library on the PC. Files will be saved to HoloLensCommander\<HoloLens address|name>.
 
 ##### Delete files after saving
 


### PR DESCRIPTION
Change the Mixed Reality Capture file save location to match the name of the application. Will now save to <pictures library>\HoloLensCommander\

Update readme.md to reflect this change (and fix related error).