### PR TITLE
explicitly request connection update

### DIFF
--- a/HoloLensCommander/HoloLensCommander/HoloLens/HoloLensMonitorCommands.cs
+++ b/HoloLensCommander/HoloLensCommander/HoloLens/HoloLensMonitorCommands.cs
@@ -44,6 +44,7 @@ namespace HoloLensCommander
             await portal.ConnectAsync(
                 null,
                 null,
+                updateConnection: true,
                 manualCertificate: certificate);
         }
 


### PR DESCRIPTION
the windows device portal wrapper project will be changing the default value of the ConnectAsync method's updateConnection argument from true to false. This change ensures the HoloLensCommander continues to work after taking future WDPW NuGet package(s).