### PR TITLE
update to WDPW 0.9.3, fix bug in info dialog

### DIFF
--- a/HoloLensCommander/HoloLensCommander/Dialogs/HoloLensInformationDialogViewModelProperties.cs
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/HoloLensInformationDialogViewModelProperties.cs
@@ -28,10 +28,7 @@ namespace HoloLensCommander
         {
             get 
             {
-                Task<string> t = this.holoLensMonitor.GetMachineNameAsync();
-                t.ConfigureAwait(false);
-                t.Wait();
-                return t.Result;
+                return this.holoLensMonitor.MachineName;
             }
         }
 

--- a/HoloLensCommander/HoloLensCommander/Dialogs/MixedRealityViewDialog.xaml
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/MixedRealityViewDialog.xaml
@@ -27,7 +27,7 @@
                 Canvas.Left="62" Canvas.Top="10"/>
         </Canvas>
         <Canvas 
-            Width="450" Height="250">
+            Width="450" Height="275">
             <MediaElement 
                 AreTransportControlsEnabled="False"
                 Source="{Binding Path=LiveViewSource}"
@@ -36,12 +36,17 @@
             </MediaElement>
         </Canvas>
         <Canvas 
-            Width="450" Height="80">
+            Width="450" Height="125">
             <TextBlock 
-                x:Name="notesLabel"
-                Text="NOTE: Starting a Mixed Reality live view may increase network bandwidth consumption and will reduce the frame rate on the HoloLens."
+                x:Name="networkBandwithLabel"
+                Text="Starting a Mixed Reality live view may increase network bandwidth consumption and will reduce the frame rate on the HoloLens."
                 TextWrapping="WrapWholeWords"
                 Width="450" Canvas.Top="10"/>
+            <TextBlock 
+                x:Name="multipleConnectionsLabel"
+                Text="Only one Mixed Reality live view connection at a time can be made to a HoloLens. The video will stop updating if another user starts an MRC live view to this HoloLens."
+                TextWrapping="WrapWholeWords"
+                Width="450" Canvas.Top="60"/>
         </Canvas>
         <Canvas
             Width="450" Height="80">

--- a/HoloLensCommander/HoloLensCommander/HoloLens/HoloLensMonitorProperties.cs
+++ b/HoloLensCommander/HoloLensCommander/HoloLens/HoloLensMonitorProperties.cs
@@ -81,6 +81,18 @@ namespace HoloLensCommander
         public float Ipd
         { get; private set; }
 
+
+        /// <summary>
+        /// Returns the name of the connected device.
+        /// </summary>
+        public string MachineName
+        {
+            get
+            {
+                return this.devicePortalConnection.OsInfo.Name;
+            }
+        }
+
         /// <summary>
         /// Returns the version of the operating system.
         /// </summary>

--- a/HoloLensCommander/HoloLensCommander/project.json
+++ b/HoloLensCommander/HoloLensCommander/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.1.0",
-	"WindowsDevicePortalWrapper": "0.9.2"
+	"WindowsDevicePortalWrapper": "0.9.3"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
now uses latest release of the WindowsDevicePortalWrapper package (closes #43)
fixes blocking bug when attempting to display the HoloLens Information Dialog