### PR TITLE
Spectator view bug fixes

### DIFF
--- a/SpectatorView/Calibration/Calibration.sln
+++ b/SpectatorView/Calibration/Calibration.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Calibration", "Calibration\Calibration.vcxproj", "{70239410-43FF-4F2B-ACBB-E640437F7289}"
 EndProject
@@ -20,9 +20,9 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{70239410-43FF-4F2B-ACBB-E640437F7289}.Debug|x64.ActiveCfg = Debug|x64
-		{70239410-43FF-4F2B-ACBB-E640437F7289}.Debug|x64.Build.0 = Debug|x64
-		{70239410-43FF-4F2B-ACBB-E640437F7289}.Debug|x86.ActiveCfg = Debug|x64
+		{70239410-43FF-4F2B-ACBB-E640437F7289}.Debug|x64.ActiveCfg = Release|x64
+		{70239410-43FF-4F2B-ACBB-E640437F7289}.Debug|x64.Build.0 = Release|x64
+		{70239410-43FF-4F2B-ACBB-E640437F7289}.Debug|x86.ActiveCfg = Release|x64
 		{70239410-43FF-4F2B-ACBB-E640437F7289}.Release|x64.ActiveCfg = Release|x64
 		{70239410-43FF-4F2B-ACBB-E640437F7289}.Release|x64.Build.0 = Release|x64
 		{70239410-43FF-4F2B-ACBB-E640437F7289}.Release|x86.ActiveCfg = Release|x64

--- a/SpectatorView/Compositor/CompositorDLL/OpenCVFrameProvider.cpp
+++ b/SpectatorView/Compositor/CompositorDLL/OpenCVFrameProvider.cpp
@@ -13,149 +13,149 @@ OpenCVFrameProvider::OpenCVFrameProvider()
 
 OpenCVFrameProvider::~OpenCVFrameProvider()
 {
-	DeleteCriticalSection(&lock);
+    DeleteCriticalSection(&lock);
 }
 
 HRESULT OpenCVFrameProvider::Initialize(ID3D11ShaderResourceView* colorSRV, ID3D11Texture2D* outputTexture)
 {
-	if (IsEnabled())
-	{
-		return S_OK;
-	}
+    if (IsEnabled())
+    {
+        return S_OK;
+    }
 
-	InitializeCriticalSection(&lock);
-	InitializeCriticalSection(&frameAccessCriticalSection);
+    InitializeCriticalSection(&lock);
+    InitializeCriticalSection(&frameAccessCriticalSection);
 
-	_colorSRV = colorSRV;
-	if (colorSRV != nullptr)
-	{
-		colorSRV->GetDevice(&_device);
-	}
+    _colorSRV = colorSRV;
+    if (colorSRV != nullptr)
+    {
+        colorSRV->GetDevice(&_device);
+    }
 
-	HRESULT hr = E_PENDING;
-	videoCapture = new cv::VideoCapture(CAMERA_ID);
+    HRESULT hr = E_PENDING;
+    videoCapture = new cv::VideoCapture(CAMERA_ID);
 
-	// Attempt to update camera resolution to desired resolution.
-	// Note: This may fail, and your capture will resume at the camera's native resolution.
-	// In this case, the Update loop will print an error with the expected frame resolution.
-	videoCapture->set(cv::CAP_PROP_FRAME_WIDTH, FRAME_WIDTH);
-	videoCapture->set(cv::CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT);
+    // Attempt to update camera resolution to desired resolution.
+    // Note: This may fail, and your capture will resume at the camera's native resolution.
+    // In this case, the Update loop will print an error with the expected frame resolution.
+    videoCapture->set(cv::CAP_PROP_FRAME_WIDTH, FRAME_WIDTH);
+    videoCapture->set(cv::CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT);
 
-	videoCapture->open(CAMERA_ID);
-	if (IsEnabled())
-	{
-		hr = S_OK;
-	}
+    videoCapture->open(CAMERA_ID);
+    if (IsEnabled())
+    {
+        hr = S_OK;
+    }
 
-	return hr;
+    return hr;
 }
 
 void OpenCVFrameProvider::Update()
 {
-	if (!IsEnabled() ||
-		_colorSRV == nullptr ||
-		_device == nullptr)
-	{
-		return;
-	}
+    if (!IsEnabled() ||
+        _colorSRV == nullptr ||
+        _device == nullptr)
+    {
+        return;
+    }
 
-	// Get frame time.
-	LARGE_INTEGER time;
-	QueryPerformanceCounter(&time);
+    // Get frame time.
+    LARGE_INTEGER time;
+    QueryPerformanceCounter(&time);
 
-	if (videoCapture->grab())
-	{
-		cachedTimestamp = time.QuadPart;
+    if (videoCapture->grab())
+    {
+        cachedTimestamp = time.QuadPart;
 
-		concurrency::create_task([=]
-		{
-			cv::Mat frame;
-			videoCapture->retrieve(frame);
+        concurrency::create_task([=]
+        {
+            cv::Mat frame;
+            videoCapture->retrieve(frame);
 
-			double width = videoCapture->get(cv::CAP_PROP_FRAME_WIDTH);
-			double height = videoCapture->get(cv::CAP_PROP_FRAME_HEIGHT);
+            double width = videoCapture->get(cv::CAP_PROP_FRAME_WIDTH);
+            double height = videoCapture->get(cv::CAP_PROP_FRAME_HEIGHT);
 
-			if (width != FRAME_WIDTH)
-			{
-				OutputDebugString(L"ERROR: captured width does not equal FRAME_WIDTH.  Expecting: ");
-				OutputDebugString(std::to_wstring(width).c_str());
-				OutputDebugString(L"\n");
-			}
+            if (width != FRAME_WIDTH)
+            {
+                OutputDebugString(L"ERROR: captured width does not equal FRAME_WIDTH.  Expecting: ");
+                OutputDebugString(std::to_wstring(width).c_str());
+                OutputDebugString(L"\n");
+            }
 
-			if (height != FRAME_HEIGHT)
-			{
-				OutputDebugString(L"ERROR: captured height does not equal FRAME_HEIGHT.  Expecting: ");
-				OutputDebugString(std::to_wstring(height).c_str());
-				OutputDebugString(L"\n");
-			}
+            if (height != FRAME_HEIGHT)
+            {
+                OutputDebugString(L"ERROR: captured height does not equal FRAME_HEIGHT.  Expecting: ");
+                OutputDebugString(std::to_wstring(height).c_str());
+                OutputDebugString(L"\n");
+            }
 
-			// OpenCV returns frames in RGB, convert to BGRA
-			DirectXHelper::ConvertRGBtoBGRA(frame.data, tmpData, width, height, true);
-			EnterCriticalSection(&lock);
-			dirtyFrame = false;
+            // OpenCV returns frames in RGB, convert to BGRA
+            DirectXHelper::ConvertRGBtoBGRA(frame.data, tmpData, width, height, true);
+            EnterCriticalSection(&lock);
+            dirtyFrame = false;
 
-			memcpy(cachedFrame, tmpData, FRAME_BUFSIZE);
+            memcpy(cachedFrame, tmpData, FRAME_BUFSIZE);
 
-			LeaveCriticalSection(&lock);
-		});
+            LeaveCriticalSection(&lock);
+        });
 
-		if (_device != nullptr && _colorSRV != nullptr)
-		{
-			EnterCriticalSection(&lock);
-			if (!dirtyFrame)
-			{
-				DirectXHelper::UpdateSRV(_device, _colorSRV, cachedFrame, FRAME_WIDTH * FRAME_BPP);
-				dirtyFrame = true;
-			}
-			LeaveCriticalSection(&lock);
+        if (_device != nullptr && _colorSRV != nullptr)
+        {
+            EnterCriticalSection(&lock);
+            if (!dirtyFrame)
+            {
+                DirectXHelper::UpdateSRV(_device, _colorSRV, cachedFrame, FRAME_WIDTH * FRAME_BPP);
+                dirtyFrame = true;
+            }
+            LeaveCriticalSection(&lock);
 
-			EnterCriticalSection(&frameAccessCriticalSection);
-			isVideoFrameReady = true;
-			LeaveCriticalSection(&frameAccessCriticalSection);
-		}
-	}
+            EnterCriticalSection(&frameAccessCriticalSection);
+            isVideoFrameReady = true;
+            LeaveCriticalSection(&frameAccessCriticalSection);
+        }
+    }
 }
 
 bool OpenCVFrameProvider::IsVideoFrameReady()
 {
-	EnterCriticalSection(&frameAccessCriticalSection);
-	bool ret = isVideoFrameReady;
-	if (isVideoFrameReady)
-	{
-		isVideoFrameReady = false;
-	}
-	LeaveCriticalSection(&frameAccessCriticalSection);
+    EnterCriticalSection(&frameAccessCriticalSection);
+    bool ret = isVideoFrameReady;
+    if (isVideoFrameReady)
+    {
+        isVideoFrameReady = false;
+    }
+    LeaveCriticalSection(&frameAccessCriticalSection);
 
-	return ret;
+    return ret;
 }
 
 LONGLONG OpenCVFrameProvider::GetTimestamp()
 {
-	return cachedTimestamp;
+    return cachedTimestamp;
 }
 
 LONGLONG OpenCVFrameProvider::GetDurationHNS()
 {
-	return (1.0f / 60.0f) * QPC_MULTIPLIER;
+    return (1.0f / 60.0f) * QPC_MULTIPLIER;
 }
 
 bool OpenCVFrameProvider::IsEnabled()
 {
-	if (videoCapture != nullptr)
-	{
-		return videoCapture->isOpened();
-	}
+    if (videoCapture != nullptr)
+    {
+        return videoCapture->isOpened();
+    }
 
-	return false;
+    return false;
 }
 
 void OpenCVFrameProvider::Dispose()
 {
-	if (videoCapture != nullptr)
-	{
-		videoCapture->release();
-		videoCapture = nullptr;
-	}
+    if (videoCapture != nullptr)
+    {
+        videoCapture->release();
+        videoCapture = nullptr;
+    }
 }
 
 #endif

--- a/SpectatorView/Compositor/CompositorDLL/OpenCVFrameProvider.cpp
+++ b/SpectatorView/Compositor/CompositorDLL/OpenCVFrameProvider.cpp
@@ -13,142 +13,149 @@ OpenCVFrameProvider::OpenCVFrameProvider()
 
 OpenCVFrameProvider::~OpenCVFrameProvider()
 {
-    DeleteCriticalSection(&lock);
+	DeleteCriticalSection(&lock);
 }
 
 HRESULT OpenCVFrameProvider::Initialize(ID3D11ShaderResourceView* colorSRV, ID3D11Texture2D* outputTexture)
 {
-    if (IsEnabled())
-    {
-        return S_OK;
-    }
+	if (IsEnabled())
+	{
+		return S_OK;
+	}
 
-    InitializeCriticalSection(&lock);
-    InitializeCriticalSection(&frameAccessCriticalSection);
+	InitializeCriticalSection(&lock);
+	InitializeCriticalSection(&frameAccessCriticalSection);
 
-    _colorSRV = colorSRV;
-    if (colorSRV != nullptr)
-    {
-        colorSRV->GetDevice(&_device);
-    }
+	_colorSRV = colorSRV;
+	if (colorSRV != nullptr)
+	{
+		colorSRV->GetDevice(&_device);
+	}
 
-    HRESULT hr = E_PENDING;
-    videoCapture = new cv::VideoCapture(CAMERA_ID);
-    videoCapture->open(CAMERA_ID);
-    if (IsEnabled())
-    {
-        hr = S_OK;
-    }
+	HRESULT hr = E_PENDING;
+	videoCapture = new cv::VideoCapture(CAMERA_ID);
 
-    return hr;
+	// Attempt to update camera resolution to desired resolution.
+	// Note: This may fail, and your capture will resume at the camera's native resolution.
+	// In this case, the Update loop will print an error with the expected frame resolution.
+	videoCapture->set(cv::CAP_PROP_FRAME_WIDTH, FRAME_WIDTH);
+	videoCapture->set(cv::CAP_PROP_FRAME_HEIGHT, FRAME_HEIGHT);
+
+	videoCapture->open(CAMERA_ID);
+	if (IsEnabled())
+	{
+		hr = S_OK;
+	}
+
+	return hr;
 }
 
 void OpenCVFrameProvider::Update()
 {
-    if (!IsEnabled() ||
-        _colorSRV == nullptr ||
-        _device == nullptr)
-    {
-        return;
-    }
+	if (!IsEnabled() ||
+		_colorSRV == nullptr ||
+		_device == nullptr)
+	{
+		return;
+	}
 
-    // Get frame time.
-    LARGE_INTEGER time;
-    QueryPerformanceCounter(&time);
+	// Get frame time.
+	LARGE_INTEGER time;
+	QueryPerformanceCounter(&time);
 
-    if (videoCapture->grab())
-    {
-        cachedTimestamp = time.QuadPart;
+	if (videoCapture->grab())
+	{
+		cachedTimestamp = time.QuadPart;
 
-        concurrency::create_task([=]
-        {
-            cv::Mat frame;
-            videoCapture->retrieve(frame);
+		concurrency::create_task([=]
+		{
+			cv::Mat frame;
+			videoCapture->retrieve(frame);
 
-            double width = videoCapture->get(cv::CAP_PROP_FRAME_WIDTH);
-            double height = videoCapture->get(cv::CAP_PROP_FRAME_HEIGHT);
+			double width = videoCapture->get(cv::CAP_PROP_FRAME_WIDTH);
+			double height = videoCapture->get(cv::CAP_PROP_FRAME_HEIGHT);
 
-            if (width != FRAME_WIDTH)
-            {
-                OutputDebugString(L"ERROR: captured width does not equal FRAME_WIDTH.  Expecting: ");
-                OutputDebugString(std::to_wstring(width).c_str());
-                OutputDebugString(L"\n");
-            }
+			if (width != FRAME_WIDTH)
+			{
+				OutputDebugString(L"ERROR: captured width does not equal FRAME_WIDTH.  Expecting: ");
+				OutputDebugString(std::to_wstring(width).c_str());
+				OutputDebugString(L"\n");
+			}
 
-            if (height != FRAME_HEIGHT)
-            {
-                OutputDebugString(L"ERROR: captured height does not equal FRAME_HEIGHT.  Expecting: ");
-                OutputDebugString(std::to_wstring(height).c_str());
-                OutputDebugString(L"\n");
-            }
+			if (height != FRAME_HEIGHT)
+			{
+				OutputDebugString(L"ERROR: captured height does not equal FRAME_HEIGHT.  Expecting: ");
+				OutputDebugString(std::to_wstring(height).c_str());
+				OutputDebugString(L"\n");
+			}
 
-            // OpenCV returns frames in RGB, convert to BGRA
-            DirectXHelper::ConvertRGBtoBGRA(frame.data, tmpData, width, height, true);
-            EnterCriticalSection(&lock);
-            dirtyFrame = false;
+			// OpenCV returns frames in RGB, convert to BGRA
+			DirectXHelper::ConvertRGBtoBGRA(frame.data, tmpData, width, height, true);
+			EnterCriticalSection(&lock);
+			dirtyFrame = false;
 
-            memcpy(cachedFrame, tmpData, FRAME_BUFSIZE);
+			memcpy(cachedFrame, tmpData, FRAME_BUFSIZE);
 
-            LeaveCriticalSection(&lock);
-        });
+			LeaveCriticalSection(&lock);
+		});
 
-        if (_device != nullptr && _colorSRV != nullptr)
-        {
-            EnterCriticalSection(&lock);
-            if (!dirtyFrame)
-            {
-                DirectXHelper::UpdateSRV(_device, _colorSRV, cachedFrame, FRAME_WIDTH * FRAME_BPP);
-                dirtyFrame = true;
-            }
-            LeaveCriticalSection(&lock);
+		if (_device != nullptr && _colorSRV != nullptr)
+		{
+			EnterCriticalSection(&lock);
+			if (!dirtyFrame)
+			{
+				DirectXHelper::UpdateSRV(_device, _colorSRV, cachedFrame, FRAME_WIDTH * FRAME_BPP);
+				dirtyFrame = true;
+			}
+			LeaveCriticalSection(&lock);
 
-            EnterCriticalSection(&frameAccessCriticalSection);
-            isVideoFrameReady = true;
-            LeaveCriticalSection(&frameAccessCriticalSection);
-        }
-    }
+			EnterCriticalSection(&frameAccessCriticalSection);
+			isVideoFrameReady = true;
+			LeaveCriticalSection(&frameAccessCriticalSection);
+		}
+	}
 }
 
 bool OpenCVFrameProvider::IsVideoFrameReady()
 {
-    EnterCriticalSection(&frameAccessCriticalSection);
-    bool ret = isVideoFrameReady;
-    if (isVideoFrameReady)
-    {
-        isVideoFrameReady = false;
-    }
-    LeaveCriticalSection(&frameAccessCriticalSection);
+	EnterCriticalSection(&frameAccessCriticalSection);
+	bool ret = isVideoFrameReady;
+	if (isVideoFrameReady)
+	{
+		isVideoFrameReady = false;
+	}
+	LeaveCriticalSection(&frameAccessCriticalSection);
 
-    return ret;
+	return ret;
 }
 
 LONGLONG OpenCVFrameProvider::GetTimestamp()
 {
-    return cachedTimestamp;
+	return cachedTimestamp;
 }
 
 LONGLONG OpenCVFrameProvider::GetDurationHNS()
 {
-    return (1.0f / 60.0f) * QPC_MULTIPLIER;
+	return (1.0f / 60.0f) * QPC_MULTIPLIER;
 }
 
 bool OpenCVFrameProvider::IsEnabled()
 {
-    if (videoCapture != nullptr)
-    {
-        return videoCapture->isOpened();
-    }
+	if (videoCapture != nullptr)
+	{
+		return videoCapture->isOpened();
+	}
 
-    return false;
+	return false;
 }
 
 void OpenCVFrameProvider::Dispose()
 {
-    if (videoCapture != nullptr)
-    {
-        videoCapture->release();
-        videoCapture = nullptr;
-    }
+	if (videoCapture != nullptr)
+	{
+		videoCapture->release();
+		videoCapture = nullptr;
+	}
 }
 
 #endif

--- a/SpectatorView/Compositor/SharedHeaders/DirectXHelper.h
+++ b/SpectatorView/Compositor/SharedHeaders/DirectXHelper.h
@@ -56,6 +56,11 @@ public:
     // Create a texture with the given bytes.
     static ID3D11Texture2D* CreateTexture(ID3D11Device* device, const byte* bytes, int width, int height, int bpp, DXGI_FORMAT textureFormat = DXGI_FORMAT_R8G8B8A8_UNORM)
     {
+		if (device == nullptr)
+		{
+			return nullptr;
+		}
+
         ID3D11Texture2D* tex;
 
         D3D11_TEXTURE2D_DESC tdesc;

--- a/SpectatorView/Compositor/SharedHeaders/DirectXHelper.h
+++ b/SpectatorView/Compositor/SharedHeaders/DirectXHelper.h
@@ -56,10 +56,10 @@ public:
     // Create a texture with the given bytes.
     static ID3D11Texture2D* CreateTexture(ID3D11Device* device, const byte* bytes, int width, int height, int bpp, DXGI_FORMAT textureFormat = DXGI_FORMAT_R8G8B8A8_UNORM)
     {
-		if (device == nullptr)
-		{
-			return nullptr;
-		}
+        if (device == nullptr)
+        {
+            return nullptr;
+        }
 
         ID3D11Texture2D* tex;
 

--- a/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphics.h
+++ b/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphics.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "IUnityInterface.h"
+
+typedef enum UnityGfxRenderer
+{
+	//kUnityGfxRendererOpenGL            =  0, // Legacy OpenGL, removed
+	kUnityGfxRendererD3D9              =  1, // Direct3D 9
+	kUnityGfxRendererD3D11             =  2, // Direct3D 11
+	kUnityGfxRendererGCM               =  3, // PlayStation 3
+	kUnityGfxRendererNull              =  4, // "null" device (used in batch mode)
+	kUnityGfxRendererOpenGLES20        =  8, // OpenGL ES 2.0
+	kUnityGfxRendererOpenGLES30        = 11, // OpenGL ES 3.0
+	kUnityGfxRendererGXM               = 12, // PlayStation Vita
+	kUnityGfxRendererPS4               = 13, // PlayStation 4
+	kUnityGfxRendererXboxOne           = 14, // Xbox One        
+	kUnityGfxRendererMetal             = 16, // iOS Metal
+	kUnityGfxRendererOpenGLCore        = 17, // OpenGL core
+	kUnityGfxRendererD3D12             = 18, // Direct3D 12
+	kUnityGfxRendererVulkan                = 21, // Vulkan
+} UnityGfxRenderer;
+
+typedef enum UnityGfxDeviceEventType
+{
+	kUnityGfxDeviceEventInitialize     = 0,
+	kUnityGfxDeviceEventShutdown       = 1,
+	kUnityGfxDeviceEventBeforeReset    = 2,
+	kUnityGfxDeviceEventAfterReset     = 3,
+} UnityGfxDeviceEventType;
+
+typedef void (UNITY_INTERFACE_API * IUnityGraphicsDeviceEventCallback)(UnityGfxDeviceEventType eventType);
+
+// Should only be used on the rendering thread unless noted otherwise.
+UNITY_DECLARE_INTERFACE(IUnityGraphics)
+{
+	UnityGfxRenderer (UNITY_INTERFACE_API * GetRenderer)(); // Thread safe
+
+	// This callback will be called when graphics device is created, destroyed, reset, etc.
+	// It is possible to miss the kUnityGfxDeviceEventInitialize event in case plugin is loaded at a later time,
+	// when the graphics device is already created.
+	void (UNITY_INTERFACE_API * RegisterDeviceEventCallback)(IUnityGraphicsDeviceEventCallback callback);
+	void (UNITY_INTERFACE_API * UnregisterDeviceEventCallback)(IUnityGraphicsDeviceEventCallback callback);
+};
+UNITY_REGISTER_INTERFACE_GUID(0x7CBA0A9CA4DDB544ULL,0x8C5AD4926EB17B11ULL,IUnityGraphics)
+
+
+
+// Certain Unity APIs (GL.IssuePluginEvent, CommandBuffer.IssuePluginEvent) can callback into native plugins.
+// Provide them with an address to a function of this signature.
+typedef void (UNITY_INTERFACE_API * UnityRenderingEvent)(int eventId);

--- a/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphics.h
+++ b/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphics.h
@@ -3,28 +3,28 @@
 
 typedef enum UnityGfxRenderer
 {
-	//kUnityGfxRendererOpenGL            =  0, // Legacy OpenGL, removed
-	kUnityGfxRendererD3D9              =  1, // Direct3D 9
-	kUnityGfxRendererD3D11             =  2, // Direct3D 11
-	kUnityGfxRendererGCM               =  3, // PlayStation 3
-	kUnityGfxRendererNull              =  4, // "null" device (used in batch mode)
-	kUnityGfxRendererOpenGLES20        =  8, // OpenGL ES 2.0
-	kUnityGfxRendererOpenGLES30        = 11, // OpenGL ES 3.0
-	kUnityGfxRendererGXM               = 12, // PlayStation Vita
-	kUnityGfxRendererPS4               = 13, // PlayStation 4
-	kUnityGfxRendererXboxOne           = 14, // Xbox One        
-	kUnityGfxRendererMetal             = 16, // iOS Metal
-	kUnityGfxRendererOpenGLCore        = 17, // OpenGL core
-	kUnityGfxRendererD3D12             = 18, // Direct3D 12
-	kUnityGfxRendererVulkan                = 21, // Vulkan
+    //kUnityGfxRendererOpenGL            =  0, // Legacy OpenGL, removed
+    kUnityGfxRendererD3D9              =  1, // Direct3D 9
+    kUnityGfxRendererD3D11             =  2, // Direct3D 11
+    kUnityGfxRendererGCM               =  3, // PlayStation 3
+    kUnityGfxRendererNull              =  4, // "null" device (used in batch mode)
+    kUnityGfxRendererOpenGLES20        =  8, // OpenGL ES 2.0
+    kUnityGfxRendererOpenGLES30        = 11, // OpenGL ES 3.0
+    kUnityGfxRendererGXM               = 12, // PlayStation Vita
+    kUnityGfxRendererPS4               = 13, // PlayStation 4
+    kUnityGfxRendererXboxOne           = 14, // Xbox One        
+    kUnityGfxRendererMetal             = 16, // iOS Metal
+    kUnityGfxRendererOpenGLCore        = 17, // OpenGL core
+    kUnityGfxRendererD3D12             = 18, // Direct3D 12
+    kUnityGfxRendererVulkan                = 21, // Vulkan
 } UnityGfxRenderer;
 
 typedef enum UnityGfxDeviceEventType
 {
-	kUnityGfxDeviceEventInitialize     = 0,
-	kUnityGfxDeviceEventShutdown       = 1,
-	kUnityGfxDeviceEventBeforeReset    = 2,
-	kUnityGfxDeviceEventAfterReset     = 3,
+    kUnityGfxDeviceEventInitialize     = 0,
+    kUnityGfxDeviceEventShutdown       = 1,
+    kUnityGfxDeviceEventBeforeReset    = 2,
+    kUnityGfxDeviceEventAfterReset     = 3,
 } UnityGfxDeviceEventType;
 
 typedef void (UNITY_INTERFACE_API * IUnityGraphicsDeviceEventCallback)(UnityGfxDeviceEventType eventType);
@@ -32,13 +32,13 @@ typedef void (UNITY_INTERFACE_API * IUnityGraphicsDeviceEventCallback)(UnityGfxD
 // Should only be used on the rendering thread unless noted otherwise.
 UNITY_DECLARE_INTERFACE(IUnityGraphics)
 {
-	UnityGfxRenderer (UNITY_INTERFACE_API * GetRenderer)(); // Thread safe
+    UnityGfxRenderer (UNITY_INTERFACE_API * GetRenderer)(); // Thread safe
 
-	// This callback will be called when graphics device is created, destroyed, reset, etc.
-	// It is possible to miss the kUnityGfxDeviceEventInitialize event in case plugin is loaded at a later time,
-	// when the graphics device is already created.
-	void (UNITY_INTERFACE_API * RegisterDeviceEventCallback)(IUnityGraphicsDeviceEventCallback callback);
-	void (UNITY_INTERFACE_API * UnregisterDeviceEventCallback)(IUnityGraphicsDeviceEventCallback callback);
+    // This callback will be called when graphics device is created, destroyed, reset, etc.
+    // It is possible to miss the kUnityGfxDeviceEventInitialize event in case plugin is loaded at a later time,
+    // when the graphics device is already created.
+    void (UNITY_INTERFACE_API * RegisterDeviceEventCallback)(IUnityGraphicsDeviceEventCallback callback);
+    void (UNITY_INTERFACE_API * UnregisterDeviceEventCallback)(IUnityGraphicsDeviceEventCallback callback);
 };
 UNITY_REGISTER_INTERFACE_GUID(0x7CBA0A9CA4DDB544ULL,0x8C5AD4926EB17B11ULL,IUnityGraphics)
 

--- a/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphicsD3D11.h
+++ b/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphicsD3D11.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "IUnityInterface.h"
+
+struct RenderSurfaceBase;
+typedef struct RenderSurfaceBase* UnityRenderBuffer;
+
+// Should only be used on the rendering thread unless noted otherwise.
+UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D11)
+{
+	ID3D11Device* (UNITY_INTERFACE_API * GetDevice)();
+
+	ID3D11Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer buffer);
+};
+UNITY_REGISTER_INTERFACE_GUID(0xAAB37EF87A87D748ULL,0xBF76967F07EFB177ULL,IUnityGraphicsD3D11)

--- a/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphicsD3D11.h
+++ b/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityGraphicsD3D11.h
@@ -7,8 +7,8 @@ typedef struct RenderSurfaceBase* UnityRenderBuffer;
 // Should only be used on the rendering thread unless noted otherwise.
 UNITY_DECLARE_INTERFACE(IUnityGraphicsD3D11)
 {
-	ID3D11Device* (UNITY_INTERFACE_API * GetDevice)();
+    ID3D11Device* (UNITY_INTERFACE_API * GetDevice)();
 
-	ID3D11Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer buffer);
+    ID3D11Resource* (UNITY_INTERFACE_API * TextureFromRenderBuffer)(UnityRenderBuffer buffer);
 };
 UNITY_REGISTER_INTERFACE_GUID(0xAAB37EF87A87D748ULL,0xBF76967F07EFB177ULL,IUnityGraphicsD3D11)

--- a/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityInterface.h
+++ b/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityInterface.h
@@ -1,0 +1,195 @@
+#pragma once
+
+// Unity native plugin API
+// Compatible with C99
+
+#if defined(__CYGWIN32__)
+	#define UNITY_INTERFACE_API __stdcall
+	#define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(WINAPI_FAMILY)
+	#define UNITY_INTERFACE_API __stdcall
+	#define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+#elif defined(__MACH__) || defined(__ANDROID__) || defined(__linux__) || defined(__QNX__)
+	#define UNITY_INTERFACE_API
+	#define UNITY_INTERFACE_EXPORT
+#else
+	#define UNITY_INTERFACE_API
+	#define UNITY_INTERFACE_EXPORT
+#endif
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// IUnityInterface is a registry of interfaces we choose to expose to plugins.
+//
+// USAGE:
+// ---------
+// To retrieve an interface a user can do the following from a plugin, assuming they have the header file for the interface:
+//
+// IMyInterface * ptr = registry->Get<IMyInterface>();
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Unity Interface GUID
+// Ensures global uniqueness.
+//
+// Template specialization is used to produce a means of looking up a GUID from its interface type at compile time.
+// The net result should compile down to passing around the GUID.
+//
+// UNITY_REGISTER_INTERFACE_GUID should be placed in the header file of any interface definition outside of all namespaces.
+// The interface structure and the registration GUID are all that is required to expose the interface to other systems.
+struct UnityInterfaceGUID
+{
+#ifdef __cplusplus
+	UnityInterfaceGUID(unsigned long long high, unsigned long long low)
+	: m_GUIDHigh(high)
+	, m_GUIDLow(low)
+	{
+	}
+
+	UnityInterfaceGUID(const UnityInterfaceGUID& other)
+	{
+		m_GUIDHigh = other.m_GUIDHigh;
+		m_GUIDLow  = other.m_GUIDLow;
+	}
+
+	UnityInterfaceGUID& operator=(const UnityInterfaceGUID& other)
+	{
+		m_GUIDHigh = other.m_GUIDHigh;
+		m_GUIDLow  = other.m_GUIDLow;
+		return *this;
+	}
+
+	bool Equals(const UnityInterfaceGUID& other)   const { return m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow == other.m_GUIDLow; }
+	bool LessThan(const UnityInterfaceGUID& other) const { return m_GUIDHigh < other.m_GUIDHigh || (m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow < other.m_GUIDLow); }
+#endif
+	unsigned long long m_GUIDHigh;
+	unsigned long long m_GUIDLow;
+};
+#ifdef __cplusplus
+inline bool operator==(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return left.Equals(right); }
+inline bool operator!=(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return !left.Equals(right); }
+inline bool operator< (const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return left.LessThan(right); }
+inline bool operator> (const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return right.LessThan(left); }
+inline bool operator>=(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return !operator< (left,right); }
+inline bool operator<=(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return !operator> (left,right); }
+#else
+typedef struct UnityInterfaceGUID UnityInterfaceGUID;
+#endif
+
+
+
+
+#ifdef __cplusplus
+	#define UNITY_DECLARE_INTERFACE(NAME) \
+	struct NAME : IUnityInterface
+
+	// Generic version of GetUnityInterfaceGUID to allow us to specialize it
+	// per interface below. The generic version has no actual implementation
+	// on purpose.
+	//
+	// If you get errors about return values related to this method then
+	// you have forgotten to include UNITY_REGISTER_INTERFACE_GUID with
+	// your interface, or it is not visible at some point when you are
+	// trying to retrieve or add an interface.
+	template<typename TYPE>
+	inline const UnityInterfaceGUID GetUnityInterfaceGUID();
+
+	// This is the macro you provide in your public interface header
+	// outside of a namespace to allow us to map between type and GUID
+	// without the user having to worry about it when attempting to
+	// add or retrieve and interface from the registry.
+	#define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE)      \
+	template<>                                                     \
+	inline const UnityInterfaceGUID GetUnityInterfaceGUID<TYPE>()  \
+	{                                                              \
+	    return UnityInterfaceGUID(HASHH,HASHL);                    \
+	}
+
+	// Same as UNITY_REGISTER_INTERFACE_GUID but allows the interface to live in
+	// a particular namespace. As long as the namespace is visible at the time you call
+	// GetUnityInterfaceGUID< INTERFACETYPE >() or you explicitly qualify it in the template
+	// calls this will work fine, only the macro here needs to have the additional parameter
+    #define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE) \
+	const UnityInterfaceGUID TYPE##_GUID(HASHH, HASHL);                               \
+	template<>                                                                        \
+	inline const UnityInterfaceGUID GetUnityInterfaceGUID< NAMESPACE :: TYPE >()      \
+	{                                                                                 \
+		return UnityInterfaceGUID(HASHH,HASHL);                                       \
+	}
+
+	// These macros allow for C compatibility in user code.
+	#define UNITY_GET_INTERFACE_GUID(TYPE) GetUnityInterfaceGUID< TYPE >()
+
+
+#else
+	#define UNITY_DECLARE_INTERFACE(NAME) \
+	typedef struct NAME NAME;             \
+	struct NAME
+
+	// NOTE: This has the downside that one some compilers it will not get stripped from all compilation units that
+	//       can see a header containing this constant. However, it's only for C compatibility and thus should have
+	//       minimal impact.
+	#define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE) \
+	const UnityInterfaceGUID TYPE##_GUID = {HASHH, HASHL};
+
+	// In general namespaces are going to be a problem for C code any interfaces we expose in a namespace are
+	// not going to be usable from C.
+	#define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE) 
+
+	// These macros allow for C compatibility in user code.
+	#define UNITY_GET_INTERFACE_GUID(TYPE) TYPE##_GUID
+#endif
+
+// Using this in user code rather than INTERFACES->Get<TYPE>() will be C compatible for those places in plugins where 
+// this may be needed. Unity code itself does not need this.
+#define UNITY_GET_INTERFACE(INTERFACES, TYPE) (TYPE*)INTERFACES->GetInterface (UNITY_GET_INTERFACE_GUID(TYPE));
+
+
+#ifdef __cplusplus
+struct IUnityInterface
+{
+};
+#else
+typedef void IUnityInterface;
+#endif
+
+
+
+typedef struct IUnityInterfaces
+{
+	// Returns an interface matching the guid.
+	// Returns nullptr if the given interface is unavailable in the active Unity runtime.
+	IUnityInterface* (UNITY_INTERFACE_API * GetInterface)(UnityInterfaceGUID guid);
+
+	// Registers a new interface.
+	void (UNITY_INTERFACE_API * RegisterInterface)(UnityInterfaceGUID guid, IUnityInterface* ptr);
+
+#ifdef __cplusplus
+	// Helper for GetInterface.
+	template <typename INTERFACE>
+	INTERFACE* Get()
+	{
+		return static_cast<INTERFACE*>(GetInterface(GetUnityInterfaceGUID<INTERFACE>()));
+	}
+
+	// Helper for RegisterInterface.
+	template <typename INTERFACE>
+	void Register(IUnityInterface* ptr)
+	{
+		RegisterInterface(GetUnityInterfaceGUID<INTERFACE>(), ptr);
+	}
+#endif
+} IUnityInterfaces;
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// If exported by a plugin, this function will be called when the plugin is loaded.
+void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginLoad(IUnityInterfaces* unityInterfaces);
+// If exported by a plugin, this function will be called when the plugin is about to be unloaded.
+void UNITY_INTERFACE_EXPORT UNITY_INTERFACE_API UnityPluginUnload();
+
+#ifdef __cplusplus
+}
+#endif

--- a/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityInterface.h
+++ b/SpectatorView/Compositor/UnityCompositorInterface/PluginAPI/IUnityInterface.h
@@ -4,17 +4,17 @@
 // Compatible with C99
 
 #if defined(__CYGWIN32__)
-	#define UNITY_INTERFACE_API __stdcall
-	#define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+    #define UNITY_INTERFACE_API __stdcall
+    #define UNITY_INTERFACE_EXPORT __declspec(dllexport)
 #elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(_WIN64) || defined(WINAPI_FAMILY)
-	#define UNITY_INTERFACE_API __stdcall
-	#define UNITY_INTERFACE_EXPORT __declspec(dllexport)
+    #define UNITY_INTERFACE_API __stdcall
+    #define UNITY_INTERFACE_EXPORT __declspec(dllexport)
 #elif defined(__MACH__) || defined(__ANDROID__) || defined(__linux__) || defined(__QNX__)
-	#define UNITY_INTERFACE_API
-	#define UNITY_INTERFACE_EXPORT
+    #define UNITY_INTERFACE_API
+    #define UNITY_INTERFACE_EXPORT
 #else
-	#define UNITY_INTERFACE_API
-	#define UNITY_INTERFACE_EXPORT
+    #define UNITY_INTERFACE_API
+    #define UNITY_INTERFACE_EXPORT
 #endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -38,30 +38,30 @@
 struct UnityInterfaceGUID
 {
 #ifdef __cplusplus
-	UnityInterfaceGUID(unsigned long long high, unsigned long long low)
-	: m_GUIDHigh(high)
-	, m_GUIDLow(low)
-	{
-	}
+    UnityInterfaceGUID(unsigned long long high, unsigned long long low)
+    : m_GUIDHigh(high)
+    , m_GUIDLow(low)
+    {
+    }
 
-	UnityInterfaceGUID(const UnityInterfaceGUID& other)
-	{
-		m_GUIDHigh = other.m_GUIDHigh;
-		m_GUIDLow  = other.m_GUIDLow;
-	}
+    UnityInterfaceGUID(const UnityInterfaceGUID& other)
+    {
+        m_GUIDHigh = other.m_GUIDHigh;
+        m_GUIDLow  = other.m_GUIDLow;
+    }
 
-	UnityInterfaceGUID& operator=(const UnityInterfaceGUID& other)
-	{
-		m_GUIDHigh = other.m_GUIDHigh;
-		m_GUIDLow  = other.m_GUIDLow;
-		return *this;
-	}
+    UnityInterfaceGUID& operator=(const UnityInterfaceGUID& other)
+    {
+        m_GUIDHigh = other.m_GUIDHigh;
+        m_GUIDLow  = other.m_GUIDLow;
+        return *this;
+    }
 
-	bool Equals(const UnityInterfaceGUID& other)   const { return m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow == other.m_GUIDLow; }
-	bool LessThan(const UnityInterfaceGUID& other) const { return m_GUIDHigh < other.m_GUIDHigh || (m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow < other.m_GUIDLow); }
+    bool Equals(const UnityInterfaceGUID& other)   const { return m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow == other.m_GUIDLow; }
+    bool LessThan(const UnityInterfaceGUID& other) const { return m_GUIDHigh < other.m_GUIDHigh || (m_GUIDHigh == other.m_GUIDHigh && m_GUIDLow < other.m_GUIDLow); }
 #endif
-	unsigned long long m_GUIDHigh;
-	unsigned long long m_GUIDLow;
+    unsigned long long m_GUIDHigh;
+    unsigned long long m_GUIDLow;
 };
 #ifdef __cplusplus
 inline bool operator==(const UnityInterfaceGUID& left, const UnityInterfaceGUID& right) { return left.Equals(right); }
@@ -78,64 +78,64 @@ typedef struct UnityInterfaceGUID UnityInterfaceGUID;
 
 
 #ifdef __cplusplus
-	#define UNITY_DECLARE_INTERFACE(NAME) \
-	struct NAME : IUnityInterface
+    #define UNITY_DECLARE_INTERFACE(NAME) \
+    struct NAME : IUnityInterface
 
-	// Generic version of GetUnityInterfaceGUID to allow us to specialize it
-	// per interface below. The generic version has no actual implementation
-	// on purpose.
-	//
-	// If you get errors about return values related to this method then
-	// you have forgotten to include UNITY_REGISTER_INTERFACE_GUID with
-	// your interface, or it is not visible at some point when you are
-	// trying to retrieve or add an interface.
-	template<typename TYPE>
-	inline const UnityInterfaceGUID GetUnityInterfaceGUID();
+    // Generic version of GetUnityInterfaceGUID to allow us to specialize it
+    // per interface below. The generic version has no actual implementation
+    // on purpose.
+    //
+    // If you get errors about return values related to this method then
+    // you have forgotten to include UNITY_REGISTER_INTERFACE_GUID with
+    // your interface, or it is not visible at some point when you are
+    // trying to retrieve or add an interface.
+    template<typename TYPE>
+    inline const UnityInterfaceGUID GetUnityInterfaceGUID();
 
-	// This is the macro you provide in your public interface header
-	// outside of a namespace to allow us to map between type and GUID
-	// without the user having to worry about it when attempting to
-	// add or retrieve and interface from the registry.
-	#define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE)      \
-	template<>                                                     \
-	inline const UnityInterfaceGUID GetUnityInterfaceGUID<TYPE>()  \
-	{                                                              \
-	    return UnityInterfaceGUID(HASHH,HASHL);                    \
-	}
+    // This is the macro you provide in your public interface header
+    // outside of a namespace to allow us to map between type and GUID
+    // without the user having to worry about it when attempting to
+    // add or retrieve and interface from the registry.
+    #define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE)      \
+    template<>                                                     \
+    inline const UnityInterfaceGUID GetUnityInterfaceGUID<TYPE>()  \
+    {                                                              \
+        return UnityInterfaceGUID(HASHH,HASHL);                    \
+    }
 
-	// Same as UNITY_REGISTER_INTERFACE_GUID but allows the interface to live in
-	// a particular namespace. As long as the namespace is visible at the time you call
-	// GetUnityInterfaceGUID< INTERFACETYPE >() or you explicitly qualify it in the template
-	// calls this will work fine, only the macro here needs to have the additional parameter
+    // Same as UNITY_REGISTER_INTERFACE_GUID but allows the interface to live in
+    // a particular namespace. As long as the namespace is visible at the time you call
+    // GetUnityInterfaceGUID< INTERFACETYPE >() or you explicitly qualify it in the template
+    // calls this will work fine, only the macro here needs to have the additional parameter
     #define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE) \
-	const UnityInterfaceGUID TYPE##_GUID(HASHH, HASHL);                               \
-	template<>                                                                        \
-	inline const UnityInterfaceGUID GetUnityInterfaceGUID< NAMESPACE :: TYPE >()      \
-	{                                                                                 \
-		return UnityInterfaceGUID(HASHH,HASHL);                                       \
-	}
+    const UnityInterfaceGUID TYPE##_GUID(HASHH, HASHL);                               \
+    template<>                                                                        \
+    inline const UnityInterfaceGUID GetUnityInterfaceGUID< NAMESPACE :: TYPE >()      \
+    {                                                                                 \
+        return UnityInterfaceGUID(HASHH,HASHL);                                       \
+    }
 
-	// These macros allow for C compatibility in user code.
-	#define UNITY_GET_INTERFACE_GUID(TYPE) GetUnityInterfaceGUID< TYPE >()
+    // These macros allow for C compatibility in user code.
+    #define UNITY_GET_INTERFACE_GUID(TYPE) GetUnityInterfaceGUID< TYPE >()
 
 
 #else
-	#define UNITY_DECLARE_INTERFACE(NAME) \
-	typedef struct NAME NAME;             \
-	struct NAME
+    #define UNITY_DECLARE_INTERFACE(NAME) \
+    typedef struct NAME NAME;             \
+    struct NAME
 
-	// NOTE: This has the downside that one some compilers it will not get stripped from all compilation units that
-	//       can see a header containing this constant. However, it's only for C compatibility and thus should have
-	//       minimal impact.
-	#define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE) \
-	const UnityInterfaceGUID TYPE##_GUID = {HASHH, HASHL};
+    // NOTE: This has the downside that one some compilers it will not get stripped from all compilation units that
+    //       can see a header containing this constant. However, it's only for C compatibility and thus should have
+    //       minimal impact.
+    #define UNITY_REGISTER_INTERFACE_GUID(HASHH, HASHL, TYPE) \
+    const UnityInterfaceGUID TYPE##_GUID = {HASHH, HASHL};
 
-	// In general namespaces are going to be a problem for C code any interfaces we expose in a namespace are
-	// not going to be usable from C.
-	#define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE) 
+    // In general namespaces are going to be a problem for C code any interfaces we expose in a namespace are
+    // not going to be usable from C.
+    #define UNITY_REGISTER_INTERFACE_GUID_IN_NAMESPACE(HASHH, HASHL, TYPE, NAMESPACE) 
 
-	// These macros allow for C compatibility in user code.
-	#define UNITY_GET_INTERFACE_GUID(TYPE) TYPE##_GUID
+    // These macros allow for C compatibility in user code.
+    #define UNITY_GET_INTERFACE_GUID(TYPE) TYPE##_GUID
 #endif
 
 // Using this in user code rather than INTERFACES->Get<TYPE>() will be C compatible for those places in plugins where 
@@ -155,27 +155,27 @@ typedef void IUnityInterface;
 
 typedef struct IUnityInterfaces
 {
-	// Returns an interface matching the guid.
-	// Returns nullptr if the given interface is unavailable in the active Unity runtime.
-	IUnityInterface* (UNITY_INTERFACE_API * GetInterface)(UnityInterfaceGUID guid);
+    // Returns an interface matching the guid.
+    // Returns nullptr if the given interface is unavailable in the active Unity runtime.
+    IUnityInterface* (UNITY_INTERFACE_API * GetInterface)(UnityInterfaceGUID guid);
 
-	// Registers a new interface.
-	void (UNITY_INTERFACE_API * RegisterInterface)(UnityInterfaceGUID guid, IUnityInterface* ptr);
+    // Registers a new interface.
+    void (UNITY_INTERFACE_API * RegisterInterface)(UnityInterfaceGUID guid, IUnityInterface* ptr);
 
 #ifdef __cplusplus
-	// Helper for GetInterface.
-	template <typename INTERFACE>
-	INTERFACE* Get()
-	{
-		return static_cast<INTERFACE*>(GetInterface(GetUnityInterfaceGUID<INTERFACE>()));
-	}
+    // Helper for GetInterface.
+    template <typename INTERFACE>
+    INTERFACE* Get()
+    {
+        return static_cast<INTERFACE*>(GetInterface(GetUnityInterfaceGUID<INTERFACE>()));
+    }
 
-	// Helper for RegisterInterface.
-	template <typename INTERFACE>
-	void Register(IUnityInterface* ptr)
-	{
-		RegisterInterface(GetUnityInterfaceGUID<INTERFACE>(), ptr);
-	}
+    // Helper for RegisterInterface.
+    template <typename INTERFACE>
+    void Register(IUnityInterface* ptr)
+    {
+        RegisterInterface(GetUnityInterfaceGUID<INTERFACE>(), ptr);
+    }
 #endif
 } IUnityInterfaces;
 

--- a/SpectatorView/Compositor/UnityCompositorInterface/UnityCompositorInterface.vcxproj
+++ b/SpectatorView/Compositor/UnityCompositorInterface/UnityCompositorInterface.vcxproj
@@ -207,6 +207,9 @@ if EXIST "$(OpenCV_vc14)" xcopy /y "$(OpenCV_vc14)\bin\*.dll"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="PluginAPI\IUnityGraphics.h" />
+    <ClInclude Include="PluginAPI\IUnityGraphicsD3D11.h" />
+    <ClInclude Include="PluginAPI\IUnityInterface.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>

--- a/SpectatorView/Compositor/UnityCompositorInterface/UnityCompositorInterface.vcxproj.filters
+++ b/SpectatorView/Compositor/UnityCompositorInterface/UnityCompositorInterface.vcxproj.filters
@@ -13,6 +13,9 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="PluginAPI">
+      <UniqueIdentifier>{d6a8fede-e8d5-4893-95db-ddb5eabd8672}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -20,6 +23,15 @@
     </ClInclude>
     <ClInclude Include="targetver.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="PluginAPI\IUnityGraphics.h">
+      <Filter>PluginAPI</Filter>
+    </ClInclude>
+    <ClInclude Include="PluginAPI\IUnityGraphicsD3D11.h">
+      <Filter>PluginAPI</Filter>
+    </ClInclude>
+    <ClInclude Include="PluginAPI\IUnityInterface.h">
+      <Filter>PluginAPI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/Editor/PreviewWindow.cs
+++ b/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/Editor/PreviewWindow.cs
@@ -52,10 +52,11 @@ public class PreviewWindow : EditorWindow
             {
                 dim = new Vector2(Screen.currentResolution.width, Screen.currentResolution.height);
             }
+
             window = ScriptableObject.CreateInstance<PreviewWindow>();
             window.maxSize = new Vector2(6000, 4000);
             window.position = new Rect(pos, dim.Value);
-            window.ShowPopup();
+            window.ShowAsDropDown(new Rect(), dim.Value);
         }
         else
         {

--- a/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/Scripts/ShaderManager.cs
+++ b/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/Scripts/ShaderManager.cs
@@ -440,7 +440,9 @@ namespace SpectatorView
         {
             if (colorTexture == null)
             {
-                if (CreateUnityColorTexture(out colorSRV))
+                // Unity 5.6 workaround:
+                // Creating textures on the graphics device on the first frame deadlocks Unity 5.6.
+                if (Time.frameCount > 1 && CreateUnityColorTexture(out colorSRV))
                 {
                     colorTexture = Texture2D.CreateExternalTexture(GetFrameWidth(), GetFrameHeight(), TextureFormat.ARGB32, false, false, colorSRV);
                     colorTexture.filterMode = FilterMode.Point;
@@ -453,7 +455,9 @@ namespace SpectatorView
         {
             if (holoTexture == null)
             {
-                if (CreateUnityHoloTexture(out holoSRV))
+                // Unity 5.6 workaround:
+                // Creating textures on the graphics device on the first frame deadlocks Unity 5.6.
+                if (Time.frameCount > 1 && CreateUnityHoloTexture(out holoSRV))
                 {
                     holoTexture = Texture2D.CreateExternalTexture(GetFrameWidth(), GetFrameHeight(), TextureFormat.ARGB32, false, false, holoSRV);
                 }


### PR DESCRIPTION
https://github.com/Microsoft/HoloLensCompanionKit/issues/94
+ Update Unity native plugin to match current Unity spec (see PluginAPI)
+ Update ShaderManager to create textures after the first frame.

https://github.com/Microsoft/HoloLensCompanionKit/issues/86
+ Update OpenCVFrameProvider to attempt to set the camera's capture resolution to the desired frame resolution.
+ Enforce release build of calibration app.  Debug builds with OpenCV tend to assert too much causing timing issues.

https://github.com/Microsoft/HoloLensCompanionKit/issues/91
+ Change preview window to a dropdown instead of a popup for better DPI awareness.
+ For best results, the windows taskbar will have to be hidden.
