### PR TITLE
Added webcam capability to Viewer

### DIFF
--- a/MixedRemoteViewCompositor/Samples/LowLatencyMRC/UWP/Viewer/Package.appxmanifest
+++ b/MixedRemoteViewCompositor/Samples/LowLatencyMRC/UWP/Viewer/Package.appxmanifest
@@ -26,5 +26,6 @@
     <Capability Name="internetClientServer" />
     <Capability Name="privateNetworkClientServer" />
     <Capability Name="internetClient" />
+    <DeviceCapability Name="webcam" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
MediaCapture initializes with an error without the Webcam capability.

The following line https://github.com/Microsoft/HoloLensCompanionKit/blob/9659e37f406bb869e64f7c21a7c27f9839f37916/MixedRemoteViewCompositor/Source/Shared/Media/CaptureEngine.cpp#L354
fails (silently without Log_Level_Warning) when attempting to run the Viewer.