### PR TITLE
Fix for list scrolling and rework connection ui

### DIFF
--- a/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialog.xaml
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialog.xaml
@@ -1,0 +1,46 @@
+﻿<ContentDialog
+    x:Class="HoloLensCommander.SetCredentialsDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:HoloLensCommander"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Device Connection Credentials"
+    PrimaryButtonText="Ok"
+    SecondaryButtonText="Cancel"
+    PrimaryButtonClick="ContentDialog_OkClick"
+    MaxHeight="350">
+
+    <StackPanel>
+        <Canvas 
+            Width="350" Height="50">
+            <TextBlock 
+                x:Name="userNameLabel"
+                Text="User name"
+                FontSize="16" 
+                Canvas.Top="16" Canvas.Left="5"/>
+            <TextBox 
+                x:Name="userName"
+                Text="{Binding Path=UserName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                ToolTipService.ToolTip="Windows Device Portal user name"
+                Width="200" 
+                Canvas.Top="10" Canvas.Left="85"/>
+        </Canvas>
+        <Canvas 
+            Width="350" Height="50">
+            <TextBlock 
+                x:Name="passwordLabel"
+                Text="Password"
+                FontSize="16" 
+                Canvas.Top="16" Canvas.Left="5"/>
+            <PasswordBox 
+                x:Name="password"
+                Password="{Binding Path=Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" 
+                ToolTipService.ToolTip="Windows Device Portal password"
+                PasswordRevealMode="Peek" 
+                Width="200" 
+                Canvas.Top="10" Canvas.Left="85"/>
+        </Canvas>
+    </StackPanel>
+</ContentDialog>

--- a/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialog.xaml.cs
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialog.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace HoloLensCommander
+{
+    public sealed partial class SetCredentialsDialog : ContentDialog
+    {
+        /// <summary>
+        /// The credentials used when connecting to a device.
+        /// </summary>
+        private NetworkCredential connectionCredentials;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetCredentialsDialog"/> class.
+        /// </summary>
+        /// <param name="credentials">Network credential object used to connect to a device.</param>
+        public SetCredentialsDialog(NetworkCredential credentials)
+        {
+            this.connectionCredentials = credentials;
+
+            this.DataContext = new SetCredentialsDialogViewModel(credentials);
+            this.InitializeComponent();
+        }
+
+        /// <summary>
+        /// Handle click event for the ok button.
+        /// </summary>
+        /// <param name="sender">The object sending the event.</param>
+        /// <param name="args">Event arguments.</param>
+        private void ContentDialog_OkClick(ContentDialog sender, 
+            ContentDialogButtonClickEventArgs args)
+        {
+            // Return the user's selections.
+            ((SetCredentialsDialogViewModel)this.DataContext).UpdateUserData(this.connectionCredentials);
+        }
+    }
+}

--- a/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialogViewModel.cs
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialogViewModel.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HoloLensCommander
+{
+    public partial class SetCredentialsDialogViewModel : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Event that is notified when a property value has changed.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SetCredentialsDialogViewModel" /> class.
+        /// </summary>
+        public SetCredentialsDialogViewModel(NetworkCredential credentials)
+        {
+            this.UserName = credentials.UserName;
+            this.Password = credentials.Password;
+        }
+
+        /// <summary>
+        /// Sends the PropertyChanged events to registered handlers.
+        /// </summary>
+        /// <param name="propertyName">The name of property that has changed.</param>
+        private void NotifyPropertyChanged(string propertyName)
+        {
+            this.PropertyChanged?.Invoke(
+                this,
+                new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// <summary>
+        /// Update's the user selected data.
+        /// </summary>
+        /// <param name="credentials">The credentials to be used to connect to the device.</param>
+        internal void UpdateUserData(NetworkCredential credentials)
+        {
+            credentials.UserName = this.UserName;
+            credentials.Password = this.Password;
+        }
+    }
+}

--- a/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialogViewModelProperties.cs
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/SetCredentialsDialogViewModelProperties.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HoloLensCommander
+{
+    public partial class SetCredentialsDialogViewModel
+    {
+        /// <summary>
+        /// Gets or sets the user name to be used when connecting to a device.
+        /// </summary>
+        private string userName = string.Empty;
+        public string UserName
+        {
+            get
+            {
+                return this.userName;
+            }
+
+            set
+            {
+                if (this.userName != value)
+                {
+                    this.userName = value;
+                    this.NotifyPropertyChanged("UserName");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the password to be used when connecting to a device.
+        /// </summary>
+        private string password = string.Empty;
+        public string Password
+        {
+            get
+            {
+                return this.password;
+            }
+
+            set
+            {
+                if (this.password != value)
+                {
+                    this.password = value;
+                    this.NotifyPropertyChanged("Password");
+                }
+            }
+        }
+
+    }
+}

--- a/HoloLensCommander/HoloLensCommander/HoloLensCommander.csproj
+++ b/HoloLensCommander/HoloLensCommander/HoloLensCommander.csproj
@@ -130,6 +130,8 @@
     <Compile Include="Dialogs\ManageAppsDialogViewModelProperties.cs" />
     <Compile Include="Dialogs\MixedRealityViewDialogViewModel.cs" />
     <Compile Include="Dialogs\MixedRealityViewDialogViewModelProperties.cs" />
+    <Compile Include="Dialogs\SetCredentialsDialogViewModel.cs" />
+    <Compile Include="Dialogs\SetCredentialsDialogViewModelProperties.cs" />
     <Compile Include="Dialogs\SetIpdDialog.xaml.cs">
       <DependentUpon>SetIpdDialog.xaml</DependentUpon>
     </Compile>
@@ -153,6 +155,9 @@
       <DependentUpon>ManageAppsDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Dialogs\SetCredentialsDialog.xaml.cs">
+      <DependentUpon>SetCredentialsDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Utilities\AppInstallFiles.cs" />
     <Compile Include="Utilities\ConnectionInformation.cs" />
     <Compile Include="Utilities\ConnectOptions.cs" />
@@ -216,6 +221,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Dialogs\ManageAppsDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Dialogs\SetCredentialsDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/HoloLensCommander/HoloLensCommander/MainPage.xaml
+++ b/HoloLensCommander/HoloLensCommander/MainPage.xaml
@@ -19,22 +19,34 @@
             <ColumnDefinition Width="600*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition Height="40"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="40"/>
         </Grid.RowDefinitions>
 
         <!-- Column 0 controls -->
-        <ScrollViewer Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"
+        <Canvas Grid.Column="0" Grid.Row="0"
+                x:Name="appControls"
+                Background="White"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+
+        </Canvas>
+        <ScrollViewer Grid.Column="0" Grid.Row="1" Grid.RowSpan="2"
             VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
             <StackPanel
                 Background="White" Height="Auto">
                 <Canvas
                     x:Name="connectionControls"
                     HorizontalAlignment="Left" VerticalAlignment="Top"
-                    Width="280" Height="175" Margin="10,0,0,0">
+                    Width="280" Height="205" Margin="10,0,0,0">
                     <Border 
                         BorderBrush="Black" BorderThickness="1"
-                        Width="280" Height="165"/>
+                        Width="280" Height="195"/>
+                    <TextBlock 
+                        x:Name="registerDeviceLabel"
+                        Text="Register Device"
+                        TextWrapping="NoWrap" FontSize="20"
+                        Canvas.Left="10" Canvas.Top="10"/>
                     <Button
                         x:Name="connectToDevice"
                         Content="Connect" 
@@ -43,7 +55,7 @@
                         IsEnabled="{Binding CredentialsSet}"
                         HorizontalAlignment="Stretch" VerticalAlignment="Top" 
                         Width="171" Height="50" FontSize="20"
-                        Canvas.Left="10" Canvas.Top="10"/>
+                        Canvas.Left="10" Canvas.Top="43"/>
                     <Button
                         x:Name="showConnectContextMenu"
                         Content="..."
@@ -54,13 +66,13 @@
                         HorizontalAlignment="Left" VerticalAlignment="Top" 
                         Width="75" Height="50" 
                         FontSize="20" 
-                        Canvas.Left="195" Canvas.Top="10"/>
+                        Canvas.Left="195" Canvas.Top="43"/>
                     <TextBlock 
                         x:Name="userNameLabel" 
                         Text="User name" 
                         HorizontalAlignment="Left" VerticalAlignment="Top"
                         FontSize="18" TextWrapping="NoWrap"
-                        Canvas.Left="10" Canvas.Top="73"/>
+                        Canvas.Left="10" Canvas.Top="106"/>
                     <TextBox
                         x:Name="userNameBox"
                         ToolTipService.ToolTip="Windows Device Portal user name"
@@ -68,14 +80,14 @@
                         TextWrapping="NoWrap"
                         HorizontalAlignment="Stretch" VerticalAlignment="Top"
                         FontSize="18"  
-                        Canvas.Left="127" Canvas.Top="73" Width="143"/>
+                        Canvas.Left="127" Canvas.Top="100" Width="143"/>
                     <TextBlock
                         x:Name="passwordLabel" 
                         Text="Password" 
                         TextWrapping="NoWrap"
                         HorizontalAlignment="Left" VerticalAlignment="Top"
                         FontSize="18"  
-                        Canvas.Left="21" Canvas.Top="120"/>
+                        Canvas.Left="21" Canvas.Top="150"/>
                     <PasswordBox
                         x:Name="passwordBox" 
                         ToolTipService.ToolTip="Windows Device Portal password"
@@ -83,7 +95,7 @@
                         HorizontalAlignment="Stretch" VerticalAlignment="Top"
                         Width="143" FontSize="18" 
                         PasswordRevealMode="Peek" 
-                        Canvas.Left="127" Canvas.Top="117"/>
+                        Canvas.Left="127" Canvas.Top="144"/>
                 </Canvas>
 
                 <Canvas
@@ -268,13 +280,13 @@
                 </Canvas>
             </StackPanel>
         </ScrollViewer>
+
         <!-- Column 1 controls -->
-        <StackPanel Grid.Column="1" Grid.Row="0"
-            Background="White" Margin="5,0,-5,0">
-            <Canvas
+        <Canvas Grid.Column="1" Grid.Row="0"
                 HorizontalAlignment="Stretch"
+                Background="White"
                 Height="40">
-                <Button 
+            <Button 
                     x:Name="selectAll"
                     Content="Select All"
                     ToolTipService.ToolTip="Selects all connected devices"
@@ -283,7 +295,7 @@
                     HorizontalAlignment="Left" VerticalAlignment="Top" 
                     Width="110" Height="30" 
                     Canvas.Left="5" Canvas.Top="5"/>
-                <Button 
+            <Button 
                     x:Name="selectNone"
                     Content="Select None"
                     ToolTipService.ToolTip="Deselects all connected devices"
@@ -292,7 +304,7 @@
                     HorizontalAlignment="Left" VerticalAlignment="Top" 
                     Width="110" Height="30" 
                     Canvas.Left="120" Canvas.Top="5"/>
-                <RadioButton 
+            <RadioButton 
                     x:Name="allDevices" 
                     GroupName="deviceTypeFilters"
                     Content="All"
@@ -300,32 +312,34 @@
                     IsChecked="True"
                     HorizontalAlignment="Left" Width="60" 
                     Canvas.Left="240" Canvas.Top="5"/>
-                <RadioButton 
+            <RadioButton 
                     x:Name="holoLensDevices" 
                     GroupName="deviceTypeFilters"
                     Content="HoloLens" 
                     Command="{Binding Path=UseHoloLensFilterCommand}"
                     HorizontalAlignment="Left" Width="110" 
                     Canvas.Left="310" Canvas.Top="5"/>
-                <RadioButton 
+            <RadioButton 
                     x:Name="desktopDevices" 
                     GroupName="deviceTypeFilters"
                     Content="Windows PC" 
                     Command="{Binding Path=UseDesktopFilterCommand}"
                     HorizontalAlignment="Left" Width="130" 
                     Canvas.Left="420" Canvas.Top="5"/>
-            </Canvas>
+        </Canvas>
+        <ScrollViewer Grid.Column="1" Grid.Row="1"
+            VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
             <ListBox 
                 x:Name="listBox" 
                 ItemsSource="{Binding Path=RegisteredDevices}"
                 Padding="0"
                 ScrollViewer.HorizontalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollMode="Auto"/>
-        </StackPanel>
-        <TextBlock Grid.Row="1" Grid.Column="1"
+        </ScrollViewer>
+        <TextBlock Grid.Row="2" Grid.Column="1"
             x:Name="statusMessage" 
             Text="{Binding Path=StatusMessage}"
             TextWrapping="NoWrap" FontSize="16"
             HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-            Margin="0,5,0,5"/>
+            Margin="5,0,0,5"/>
     </Grid>
 </Page>

--- a/HoloLensCommander/HoloLensCommander/MainPage.xaml
+++ b/HoloLensCommander/HoloLensCommander/MainPage.xaml
@@ -107,7 +107,7 @@
                         Width="280" Height="305"/>
                     <TextBlock 
                         x:Name="commonAppsLabel" 
-                        Text="Applications" 
+                        Text="Common Applications" 
                         TextWrapping="NoWrap" FontSize="20"
                         Canvas.Left="10" Canvas.Top="10"/>
                     <ComboBox 
@@ -182,10 +182,10 @@
                 <Canvas
                     x:Name="mixedRealityControls"
                     HorizontalAlignment="Left" VerticalAlignment="Top"
-                    Width="280" Height="160" Margin="10,0,0,0">
+                    Width="280" Height="210" Margin="10,0,0,0">
                     <Border 
                         BorderBrush="Black" BorderThickness="1"
-                        Width="280" Height="150"/>
+                        Width="280" Height="200"/>
                     <TextBlock 
                         x:Name="mixedRealityLabel"
                         Text="Mixed Reality Capture"
@@ -222,26 +222,26 @@
                         IsChecked="{Binding DeleteMixedRealityFilesAfterSave, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                         IsEnabled="{Binding HaveRegisteredDevices}"
                         FontSize="18"
-                        Canvas.Left="10" Canvas.Top="108"/>
+                        Canvas.Left="10" Canvas.Top="102"/>
+                    <Button
+                            x:Name="wipeCameraRoll"
+                            Content="Clear Camera Roll"
+                            ToolTipService.ToolTip="Remove camera roll files"
+                            Command="{Binding WipeCameraRollCommand}" 
+                            IsEnabled="{Binding HaveRegisteredDevices}"
+                            HorizontalAlignment="Right" VerticalAlignment="Top" 
+                            Width="260" Height="50" 
+                            FontSize="20" Canvas.Left="10" Canvas.Top="139"/>
                 </Canvas>
 
                 <Canvas
                     x:Name="deviceControls"
                     HorizontalAlignment="Left" VerticalAlignment="Top"
-                    Width="280" Height="190" Margin="10,0,0,0">
+                    Width="280" Height="115" Margin="10,0,0,0">
                     <Border 
                         BorderBrush="Black" BorderThickness="1"
-                        Width="280" Height="177">
+                        Width="280" Height="105">
                     </Border>
-                    <Button
-                            x:Name="wipeCameraRoll"
-                            Content="&#xE74D;"
-                            ToolTipService.ToolTip="Wipe camera roll"
-                            Command="{Binding WipeCameraRollCommand}" 
-                            IsEnabled="{Binding HaveRegisteredDevices}"
-                            HorizontalAlignment="Right" VerticalAlignment="Top" 
-                            Width="260" Height="50" 
-                            FontFamily="Segoe MDL2 Assets" FontSize="20" Canvas.Left="10" Canvas.Top="110"/>
                     <TextBlock 
                         x:Name="deviceControl"
                         Text="Device Control"
@@ -270,7 +270,7 @@
                     <Button
                         x:Name="forgetDevices"
                         Content="&#xE74D;"
-                        ToolTipService.ToolTip="Remove all connected devices"
+                        ToolTipService.ToolTip="Unregister ALL connected devices"
                         Command="{Binding ForgetConnectionsCommand}" 
                         IsEnabled="{Binding Path=HaveRegisteredDevices}"
                         HorizontalAlignment="Right" VerticalAlignment="Top" 

--- a/HoloLensCommander/HoloLensCommander/MainPage.xaml
+++ b/HoloLensCommander/HoloLensCommander/MainPage.xaml
@@ -29,75 +29,41 @@
                 x:Name="appControls"
                 Background="White"
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-
+            <Button 
+                x:Name="connectToDevice"
+                Content="Connect"
+                ToolTipService.ToolTip="Connect to your device"
+                Command="{Binding Path=ConnectToDeviceCommand}" 
+                IsEnabled="{Binding Path=CredentialsSet}"
+                Width="75" Height="30"
+                Canvas.Top="5" Canvas.Left="10"/>
+            <Button 
+                Content="&#xE192;" 
+                ToolTipService.ToolTip="Set the connection credentials"
+                Command="{Binding Path=ShowSetCredentialsCommand}"
+                FontFamily="Segoe MDL2 Assets"
+                Width="50" Height="30"
+                Canvas.Top="5" Canvas.Left="90"/>
+            <Button 
+                Content="&#xE179;" 
+                ToolTipService.ToolTip="Reconnect to previous devices"
+                Command="{Binding Path=ReconnectPreviousSessionCommand}"
+                IsEnabled="{Binding Path=CanReconnectDevices}"
+                FontFamily="Segoe MDL2 Assets"
+                Width="50" Height="30"
+                Canvas.Top="5" Canvas.Left="145"/>
+            <!-- TODO: <Button 
+                Content="&#xE115;" 
+                ToolTipService.ToolTip="Adjust application settings"
+                Command="{Binding Path=ShowSettingsCommand}"
+                FontFamily="Segoe MDL2 Assets"
+                Width="50" Height="30" 
+                Canvas.Top="5" Canvas.Left="240"/>-->
         </Canvas>
         <ScrollViewer Grid.Column="0" Grid.Row="1" Grid.RowSpan="2"
             VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">
             <StackPanel
                 Background="White" Height="Auto">
-                <Canvas
-                    x:Name="connectionControls"
-                    HorizontalAlignment="Left" VerticalAlignment="Top"
-                    Width="280" Height="205" Margin="10,0,0,0">
-                    <Border 
-                        BorderBrush="Black" BorderThickness="1"
-                        Width="280" Height="195"/>
-                    <TextBlock 
-                        x:Name="registerDeviceLabel"
-                        Text="Register Device"
-                        TextWrapping="NoWrap" FontSize="20"
-                        Canvas.Left="10" Canvas.Top="10"/>
-                    <Button
-                        x:Name="connectToDevice"
-                        Content="Connect" 
-                        ToolTipService.ToolTip="Connect to your device"
-                        Command="{Binding ConnectToDeviceCommand}" 
-                        IsEnabled="{Binding CredentialsSet}"
-                        HorizontalAlignment="Stretch" VerticalAlignment="Top" 
-                        Width="171" Height="50" FontSize="20"
-                        Canvas.Left="10" Canvas.Top="43"/>
-                    <Button
-                        x:Name="showConnectContextMenu"
-                        Content="..."
-                        Command="{Binding Path=ShowConnectContextMenuCommand}" 
-                        CommandParameter="{Binding RelativeSource={RelativeSource Self}}"
-                        ToolTipService.ToolTip="Display additional connection options."
-                        IsEnabled="{Binding CredentialsSet}"
-                        HorizontalAlignment="Left" VerticalAlignment="Top" 
-                        Width="75" Height="50" 
-                        FontSize="20" 
-                        Canvas.Left="195" Canvas.Top="43"/>
-                    <TextBlock 
-                        x:Name="userNameLabel" 
-                        Text="User name" 
-                        HorizontalAlignment="Left" VerticalAlignment="Top"
-                        FontSize="18" TextWrapping="NoWrap"
-                        Canvas.Left="10" Canvas.Top="106"/>
-                    <TextBox
-                        x:Name="userNameBox"
-                        ToolTipService.ToolTip="Windows Device Portal user name"
-                        Text="{Binding Path=UserName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        TextWrapping="NoWrap"
-                        HorizontalAlignment="Stretch" VerticalAlignment="Top"
-                        FontSize="18"  
-                        Canvas.Left="127" Canvas.Top="100" Width="143"/>
-                    <TextBlock
-                        x:Name="passwordLabel" 
-                        Text="Password" 
-                        TextWrapping="NoWrap"
-                        HorizontalAlignment="Left" VerticalAlignment="Top"
-                        FontSize="18"  
-                        Canvas.Left="21" Canvas.Top="150"/>
-                    <PasswordBox
-                        x:Name="passwordBox" 
-                        ToolTipService.ToolTip="Windows Device Portal password"
-                        Password="{Binding Path=Password, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        HorizontalAlignment="Stretch" VerticalAlignment="Top"
-                        Width="143" FontSize="18" 
-                        PasswordRevealMode="Peek" 
-                        Canvas.Left="127" Canvas.Top="144"/>
-                </Canvas>
-
                 <Canvas
                     x:Name="applicationControls"
                     HorizontalAlignment="Left" VerticalAlignment="Top"

--- a/HoloLensCommander/HoloLensCommander/MainWindowViewModel.cs
+++ b/HoloLensCommander/HoloLensCommander/MainWindowViewModel.cs
@@ -214,10 +214,10 @@ namespace HoloLensCommander
                     await this.RebootDevicesAsync();
                 });
 
-            this.ReconnectToDevicesCommand= new Command(
-                async (parameter) =>
+            this.ReconnectPreviousSessionCommand = new Command(
+                (parameter) =>
                 {
-                    await this.ReconnectToDevicesAsync();
+                    this.ReconnectPreviousSession();
                 });
 
             this.SaveMixedRealityFilesCommand = new Command(
@@ -232,10 +232,10 @@ namespace HoloLensCommander
                     this.SelectAllDevices();
                 });
 
-            this.ShowConnectContextMenuCommand = new Command(
+            this.ShowSetCredentialsCommand = new Command(
                 async (parameter) =>
                 {
-                    await this.ShowConnectContextMenuAsync(parameter);
+                    await this.ShowSetCredentials();
                 });
 
             this.ShutdownDevicesCommand = new Command(

--- a/HoloLensCommander/HoloLensCommander/MainWindowViewModelProperties.cs
+++ b/HoloLensCommander/HoloLensCommander/MainWindowViewModelProperties.cs
@@ -161,7 +161,6 @@ namespace HoloLensCommander
                 if (this.password != value)
                 {
                     this.password = value;
-                    this.NotifyPropertyChanged("Password");
                     this.UpdateCredentialsSet();
                 }
             }
@@ -192,7 +191,6 @@ namespace HoloLensCommander
                 if (this.userName != value)
                 {
                     this.userName = value;
-                    this.NotifyPropertyChanged("UserName");
                     this.UpdateCredentialsSet();
                 }
             }


### PR DESCRIPTION
Implement fix for device list failing to scroll (vertically) properly. ( Closes #107 )

Replace the previous device connection control canvas with Connect, Set Credentials and Restore Previous Connections buttons. This allows the connection ui to always be visible, even when the sidebar has been scrolled. This also makes the restore previous option to be more discoverable,

Move the Wipe Camera Roll button from Device Controls to Mixed Reality Capture controls as it is more of an MRC option than it is device control.