### PR TITLE
Device conenction / registration behavior update

### DIFF
--- a/HoloLensCommander/HoloLensCommander/Controls/DeviceMonitorControlViewModelCommands.cs
+++ b/HoloLensCommander/HoloLensCommander/Controls/DeviceMonitorControlViewModelCommands.cs
@@ -97,7 +97,7 @@ namespace HoloLensCommander
                 ContextMenuCommandHandler,
                 MonitorContextMenuCommandIds.DevicePortal));
             contextMenu.Commands.Add(new UICommand(
-                "Disconnect",
+                "Unregister",
                 ContextMenuCommandHandler,
                 MonitorContextMenuCommandIds.Disconnect));
 

--- a/HoloLensCommander/HoloLensCommander/Controls/DeviceMonitorControlViewModelProperties.cs
+++ b/HoloLensCommander/HoloLensCommander/Controls/DeviceMonitorControlViewModelProperties.cs
@@ -57,7 +57,7 @@ namespace HoloLensCommander
         /// <summary>
         /// Gets the device type label for this device.
         /// </summary>
-        private string deviceTypeLabel = DeviceIsUnknownLabel;
+        private string deviceTypeLabel = ConnectionNotEstablishedLabel;
         public string DeviceTypeLabel
         {
             get

--- a/HoloLensCommander/HoloLensCommander/Device/DeviceMonitor.cs
+++ b/HoloLensCommander/HoloLensCommander/Device/DeviceMonitor.cs
@@ -58,6 +58,14 @@ namespace HoloLensCommander
         private static readonly string ShellApp = "HoloShellApp.exe";
 
         /// <summary>
+        /// Options used to connect to this device.
+        /// </summary>
+        /// <remarks>
+        /// This data is displayed until an initial connection is made to the device.
+        /// </remarks>
+        private ConnectOptions connectOptions;
+
+        /// <summary>
         /// Dispatcher that allows heartbeats to be marshaled appropriately.
         /// </summary>
         private CoreDispatcher dispatcher;
@@ -71,6 +79,11 @@ namespace HoloLensCommander
         /// Instance of the DevicePortal used to communicate with this device.
         /// </summary>
         private DevicePortal devicePortal;
+
+        /// <summary>
+        /// Has a successful heartbeat been received from the device?
+        /// </summary>
+        private bool firstContact;
 
         /// <summary>
         /// The current heartbeat interval, in seconds.
@@ -124,9 +137,9 @@ namespace HoloLensCommander
             }
 
             this.heartbeatInterval = heartbeatInterval;
+            this.firstContact = false;
 
             // Create the timer, but do not start it.
-            // It will be started when ConnectAsync is called.
             this.heartbeatTimer = new Timer(
                 HeartbeatCallback,
                 null,
@@ -170,28 +183,31 @@ namespace HoloLensCommander
         {
             try
             {
-                // Suspend the timer.
-                heartbeatTimer.Change(
-                    Timeout.Infinite, 
-                    Timeout.Infinite);
+                this.SuspendHeartbeat();
 
                 try
                 {
-                    await UpdateBatteryStatus();
-                    await UpdateIpd();
-                    await UpdateThermalStage();
+                    // Have connected to the device the first time?
+                    if (!this.firstContact)
+                    {
+                        // Try to connect now.
+                        await this.EstablishConnection();
+                    }
 
-                    NotifyHeartbeatReceived();
+                    // TODO: this.MachineName = await this.GetMachineNameAsync();
+                    await this.UpdateBatteryStatus();
+                    await this.UpdateIpd();
+                    await this.UpdateThermalStage();
+
+                    this.NotifyHeartbeatReceived();
                 }
                 catch
                 {
-                    NotifyHeartbeatLost();
+                    this.NotifyHeartbeatLost();
                 }
-                      
+
                 // Resume the timer.
-                heartbeatTimer.Change(
-                    (Int32)(heartbeatInterval * 1000.0f), 
-                    Timeout.Infinite);
+                this.StartHeartbeat();
             }
             catch
             {
@@ -253,12 +269,40 @@ namespace HoloLensCommander
         }
 
         /// <summary>
+        /// Starts/restarts the heartbeat timer by setting a non-infinite interval
+        /// </summary>
+        internal void StartHeartbeat()
+        {
+            this.UpdateHeartbeat(
+                (int)(this.HeartbeatIntervalSeconds * 1000.0f));
+        }
+
+        /// <summary>
+        /// Suspends the heartbeat timer by setting an infinite interval
+        /// </summary>
+        internal void SuspendHeartbeat()
+        {
+            this.UpdateHeartbeat(Timeout.Infinite);
+        }
+
+        /// <summary>
         /// Updates the cached battery data.
         /// </summary>
         /// <returns>Task object used for tracking method completion.</returns>
         private async Task UpdateBatteryStatus()
         {
             this.BatteryState = await this.devicePortal.GetBatteryStateAsync();
+        }
+
+        /// <summary>
+        /// Update the heartbeat timer's due time.
+        /// </summary>
+        /// <param name="dueTimeMs">Milliseconds for the timer to wait until the next tick.</param>
+        private void UpdateHeartbeat(int dueTimeMs)
+        {
+            this.heartbeatTimer.Change(
+                dueTimeMs,
+                Timeout.Infinite);
         }
 
         /// <summary>

--- a/HoloLensCommander/HoloLensCommander/Device/DeviceMonitorCommands.cs
+++ b/HoloLensCommander/HoloLensCommander/Device/DeviceMonitorCommands.cs
@@ -107,6 +107,7 @@ namespace HoloLensCommander
                 this.devicePortal.AppInstallStatus += DevicePortal_AppInstallStatus;
                 this.devicePortal.ConnectionStatus -= DevicePortal_ConnectionStatus;
 
+                // TODO:
                 //    if (this.connectOptions.DeployNameToDevice)
                 //    {
                 //        if (await this.SetDeviceNameAsync(this.connectOptions.Name))

--- a/HoloLensCommander/HoloLensCommander/Dialogs/ConnectToDeviceDialog.xaml
+++ b/HoloLensCommander/HoloLensCommander/Dialogs/ConnectToDeviceDialog.xaml
@@ -6,7 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    Title="Connect to your device"
+    Title="Register your device"
     PrimaryButtonText="Ok"
     SecondaryButtonText="Cancel"
     PrimaryButtonClick="ContentDialog_OkClick"

--- a/HoloLensCommander/HoloLensCommander/HoloLensCommander.csproj
+++ b/HoloLensCommander/HoloLensCommander/HoloLensCommander.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Utilities\AppInstallFiles.cs" />
     <Compile Include="Utilities\ConnectionInformation.cs" />
     <Compile Include="Utilities\ConnectOptions.cs" />
+    <Compile Include="Utilities\DeviceMonitorControlComparer.cs" />
     <Compile Include="Utilities\Enums.cs" />
     <Compile Include="Utilities\Command.cs" />
     <Compile Include="Dialogs\YesNoMessageDialog.cs" />

--- a/HoloLensCommander/HoloLensCommander/MainPage.xaml
+++ b/HoloLensCommander/HoloLensCommander/MainPage.xaml
@@ -31,8 +31,8 @@
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
             <Button 
                 x:Name="connectToDevice"
-                Content="Connect"
-                ToolTipService.ToolTip="Connect to your device"
+                Content="Register"
+                ToolTipService.ToolTip="Register your device"
                 Command="{Binding Path=ConnectToDeviceCommand}" 
                 IsEnabled="{Binding Path=CredentialsSet}"
                 Width="75" Height="30"

--- a/HoloLensCommander/HoloLensCommander/MainPage.xaml
+++ b/HoloLensCommander/HoloLensCommander/MainPage.xaml
@@ -19,7 +19,7 @@
             <ColumnDefinition Width="600*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition Height="40"/>
+            <RowDefinition Height="50"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="40"/>
         </Grid.RowDefinitions>
@@ -35,22 +35,22 @@
                 ToolTipService.ToolTip="Register your device"
                 Command="{Binding Path=ConnectToDeviceCommand}" 
                 IsEnabled="{Binding Path=CredentialsSet}"
-                Width="75" Height="30"
+                Width="75" Height="40"
                 Canvas.Top="5" Canvas.Left="10"/>
             <Button 
                 Content="&#xE192;" 
                 ToolTipService.ToolTip="Set the connection credentials"
                 Command="{Binding Path=ShowSetCredentialsCommand}"
                 FontFamily="Segoe MDL2 Assets"
-                Width="50" Height="30"
+                Width="50" Height="40"
                 Canvas.Top="5" Canvas.Left="90"/>
             <Button 
                 Content="&#xE179;" 
-                ToolTipService.ToolTip="Reconnect to previous devices"
+                ToolTipService.ToolTip="Reconnect to previous device session"
                 Command="{Binding Path=ReconnectPreviousSessionCommand}"
                 IsEnabled="{Binding Path=CanReconnectDevices}"
                 FontFamily="Segoe MDL2 Assets"
-                Width="50" Height="30"
+                Width="50" Height="40"
                 Canvas.Top="5" Canvas.Left="145"/>
             <!-- TODO: <Button 
                 Content="&#xE115;" 
@@ -250,8 +250,7 @@
         <!-- Column 1 controls -->
         <Canvas Grid.Column="1" Grid.Row="0"
                 HorizontalAlignment="Stretch"
-                Background="White"
-                Height="40">
+                Background="White">
             <Button 
                     x:Name="selectAll"
                     Content="Select All"
@@ -259,7 +258,7 @@
                     Command="{Binding Path=SelectAllDevicesCommand}" 
                     IsEnabled="{Binding Path=HaveRegisteredDevices}"
                     HorizontalAlignment="Left" VerticalAlignment="Top" 
-                    Width="110" Height="30" 
+                    Width="110" Height="40" 
                     Canvas.Left="5" Canvas.Top="5"/>
             <Button 
                     x:Name="selectNone"
@@ -268,7 +267,7 @@
                     Command="{Binding Path=DeselectAllDevicesCommand}" 
                     IsEnabled="{Binding Path=HaveRegisteredDevices}"
                     HorizontalAlignment="Left" VerticalAlignment="Top" 
-                    Width="110" Height="30" 
+                    Width="110" Height="40" 
                     Canvas.Left="120" Canvas.Top="5"/>
             <RadioButton 
                     x:Name="allDevices" 
@@ -277,21 +276,21 @@
                     Command="{Binding Path=UseAllDevicesFilterCommand}"
                     IsChecked="True"
                     HorizontalAlignment="Left" Width="60" 
-                    Canvas.Left="240" Canvas.Top="5"/>
+                    Canvas.Left="240" Canvas.Top="8"/>
             <RadioButton 
                     x:Name="holoLensDevices" 
                     GroupName="deviceTypeFilters"
                     Content="HoloLens" 
                     Command="{Binding Path=UseHoloLensFilterCommand}"
                     HorizontalAlignment="Left" Width="110" 
-                    Canvas.Left="310" Canvas.Top="5"/>
+                    Canvas.Left="310" Canvas.Top="8"/>
             <RadioButton 
                     x:Name="desktopDevices" 
                     GroupName="deviceTypeFilters"
                     Content="Windows PC" 
                     Command="{Binding Path=UseDesktopFilterCommand}"
                     HorizontalAlignment="Left" Width="130" 
-                    Canvas.Left="420" Canvas.Top="5"/>
+                    Canvas.Left="420" Canvas.Top="8"/>
         </Canvas>
         <ScrollViewer Grid.Column="1" Grid.Row="1"
             VerticalScrollBarVisibility="Auto" VerticalScrollMode="Auto">

--- a/HoloLensCommander/HoloLensCommander/Package.appxmanifest
+++ b/HoloLensCommander/HoloLensCommander/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="HoloLensCommander" Publisher="CN=HoloLensCommander" Version="2.0.0.0" />
+  <Identity Name="HoloLensCommander" Publisher="CN=HoloLensCommander" Version="2.1706.0.0" />
   <mp:PhoneIdentity PhoneProductId="2ddfe2f3-79a6-4751-9a5c-56c49317682a" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Windows Mixed Reality Commander</DisplayName>

--- a/HoloLensCommander/HoloLensCommander/Properties/AssemblyInfo.cs
+++ b/HoloLensCommander/HoloLensCommander/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("HoloLensCommander")]
-[assembly: AssemblyDescription("Msonitor and manage multiple Windows Mixed Reality devices.")]
+[assembly: AssemblyDescription("Monitor and manage multiple Windows Mixed Reality devices.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("HoloLensCommander")]

--- a/HoloLensCommander/HoloLensCommander/Properties/AssemblyInfo.cs
+++ b/HoloLensCommander/HoloLensCommander/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Resources;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -6,11 +7,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("HoloLensCommander")]
-[assembly: AssemblyDescription("Application to monitor and manage multiple Windows Mixed Reality devices.")]
+[assembly: AssemblyDescription("Msonitor and manage multiple Windows Mixed Reality devices.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("HoloLensCommander")]
-[assembly: AssemblyCopyright("Copyright © 2016-17")]
+[assembly: AssemblyCopyright("Copyright © 2016-2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -24,6 +25,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("2.1706.0.0")]
+[assembly: AssemblyFileVersion("2.1706.0.0")]
 [assembly: ComVisible(false)]
+[assembly: NeutralResourcesLanguage("en-US")]
+

--- a/HoloLensCommander/HoloLensCommander/Utilities/DeviceMonitorControlComparer.cs
+++ b/HoloLensCommander/HoloLensCommander/Utilities/DeviceMonitorControlComparer.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+
+namespace HoloLensCommander
+{
+    /// <summary>
+    /// Implementation of IComparer<T> for DeviceMonitorControl objects.
+    /// </summary>
+    public class DeviceMonitorControlComparer : IComparer<DeviceMonitorControl>
+    {
+        /// <summary>
+        /// Compare two DeviceMonitorControl objects.
+        /// </summary>
+        /// <param name="x">The DeviceMonitorControl object.</param>
+        /// <param name="x">The DeviceMonitorControl object which will be compared to x.</param>
+        /// <returns>0 if the objects are equivalent, 1 if x sorts in front of y, -1 otherwise.</returns>
+        public int Compare(DeviceMonitorControl x, DeviceMonitorControl y)
+        {
+            // Get the view model for each device
+            DeviceMonitorControlViewModel xViewModel = (DeviceMonitorControlViewModel)x.DataContext;
+            DeviceMonitorControlViewModel yViewModel = (DeviceMonitorControlViewModel)y.DataContext;
+
+            // Sort by name
+            int comparisonResult = string.Compare(
+                xViewModel.Name,
+                yViewModel.Name);
+
+            if (string.IsNullOrWhiteSpace(xViewModel.Name) ||
+                 string.IsNullOrWhiteSpace(yViewModel.Name))
+            {
+                // Sort empty names last
+                comparisonResult = -(comparisonResult);
+            }
+
+            if (0 == comparisonResult)
+            {
+                // Names were equivalent, sort by address
+                comparisonResult = string.Compare(
+                    xViewModel.Address, 
+                    yViewModel.Address);
+            }
+
+            return comparisonResult;
+        }
+    }
+}


### PR DESCRIPTION
* Allow registering (connecting) an unreachable IP address. The heartbeat will complete the connection when the device is reachable.
* Improve reconnection performance by suppressing common application updates until all devices have been registered.
* Add "!" indicator on the DeviceMonitorControl to signify a device for which an initial connection has yet to be established,
* Rename Connect -> Register and Disconnect -> Unregister to clarify that connecting and disconnecting updates the session.
* Increase the height of the top grid row to avoid text clipping in buttons.

Closes #102.
Closes #112.