### PR TITLE
Spectator view bug fixes

### DIFF
--- a/SpectatorView/Calibration/Calibration.sln
+++ b/SpectatorView/Calibration/Calibration.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Calibration", "Calibration\Calibration.vcxproj", "{70239410-43FF-4F2B-ACBB-E640437F7289}"
 EndProject

--- a/SpectatorView/Compositor/Compositor.sln
+++ b/SpectatorView/Compositor/Compositor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnityCompositorInterface", "UnityCompositorInterface\UnityCompositorInterface.vcxproj", "{7EEE5BF7-87D2-42C9-AB5E-699EA3EEA423}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/SpectatorView/Compositor/CompositorDLL/CompositorInterface.h
+++ b/SpectatorView/Compositor/CompositorDLL/CompositorInterface.h
@@ -43,6 +43,7 @@ private:
     ID3D11Device* _device;
 
     HologramQueue* hologramQueue;
+    LONGLONG stubVideoTime = 0;
 
 #if USE_CANON_SDK
     CanonSDKManager* canonManager;

--- a/SpectatorView/Compositor/CompositorDLL/DeckLinkDevice.h
+++ b/SpectatorView/Compositor/CompositorDLL/DeckLinkDevice.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#if USE_DECKLINK
+#if USE_DECKLINK || USE_DECKLINK_SHUTTLE
 
 #include <Windows.h>
 #include <vector>

--- a/SpectatorView/Compositor/CompositorDLL/DeckLinkManager.cpp
+++ b/SpectatorView/Compositor/CompositorDLL/DeckLinkManager.cpp
@@ -4,7 +4,7 @@
 #include "stdafx.h"
 #include "DeckLinkManager.h"
 
-#if USE_DECKLINK
+#if USE_DECKLINK || USE_DECKLINK_SHUTTLE
 
 DeckLinkManager::DeckLinkManager(bool useCPU, bool passthroughOutput)
 {
@@ -69,10 +69,16 @@ HRESULT DeckLinkManager::Initialize(ID3D11ShaderResourceView* colorSRV, ID3D11Te
                     else if (FRAME_HEIGHT >= 1080 && FRAME_HEIGHT < 2160)
                     {
                         videoDisplayMode = bmdModeHD1080p5994;
+#if USE_DECKLINK_SHUTTLE
+                        videoDisplayMode = bmdModeHD1080p2398;
+#endif
                     }
                     else if (FRAME_HEIGHT == 2160)
                     {
                         videoDisplayMode = bmdMode4K2160p5994;
+#if USE_DECKLINK_SHUTTLE
+                        videoDisplayMode = bmdMode4K2160p2398;
+#endif
                     }
                     else if (FRAME_HEIGHT > 2160)
                     {

--- a/SpectatorView/Compositor/CompositorDLL/DeckLinkManager.h
+++ b/SpectatorView/Compositor/CompositorDLL/DeckLinkManager.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#if USE_DECKLINK
+#if USE_DECKLINK || USE_DECKLINK_SHUTTLE
 
 #include "IFrameProvider.h"
 #include "DeckLinkDevice.h"

--- a/SpectatorView/Compositor/CompositorDLL/ElgatoFrameProvider.cpp
+++ b/SpectatorView/Compositor/CompositorDLL/ElgatoFrameProvider.cpp
@@ -88,12 +88,17 @@ LONGLONG ElgatoFrameProvider::GetTimestamp()
 
 LONGLONG ElgatoFrameProvider::GetDurationHNS()
 {
-    return (LONGLONG)((1.0f / 60.0f) * QPC_MULTIPLIER);
+    return (LONGLONG)((1.0f / 30.0f) * QPC_MULTIPLIER);
 }
 
 bool ElgatoFrameProvider::IsEnabled()
 {
-    return isEnabled;
+    if (frameCallback == nullptr)
+    {
+        return false;
+    }
+
+    return frameCallback->IsEnabled();
 }
 
 void ElgatoFrameProvider::Dispose()
@@ -264,7 +269,7 @@ HRESULT ElgatoFrameProvider::SetSampleGrabberParameters()
     ZeroMemory(&vih, sizeof(VIDEOINFOHEADER));
     vih.rcTarget.right = FRAME_WIDTH;
     vih.rcTarget.bottom = FRAME_HEIGHT;
-    vih.AvgTimePerFrame = (REFERENCE_TIME)((1.0f / 60.0f) * QPC_MULTIPLIER);
+    vih.AvgTimePerFrame = (REFERENCE_TIME)((1.0f / 30.0f) * QPC_MULTIPLIER);
     vih.bmiHeader.biWidth = FRAME_WIDTH;
     vih.bmiHeader.biHeight = FRAME_HEIGHT;
     vih.bmiHeader.biSizeImage = FRAME_WIDTH * FRAME_HEIGHT * FRAME_BPP_RAW;

--- a/SpectatorView/Compositor/CompositorDLL/ElgatoSampleCallback.cpp
+++ b/SpectatorView/Compositor/CompositorDLL/ElgatoSampleCallback.cpp
@@ -13,10 +13,13 @@ ElgatoSampleCallback::ElgatoSampleCallback(ID3D11Device* device) :
 
 ElgatoSampleCallback::~ElgatoSampleCallback()
 {
+    isEnabled = false;
 }
 
 STDMETHODIMP ElgatoSampleCallback::BufferCB(double time, BYTE *pBuffer, long length)
 {
+    isEnabled = true;
+
     // Get frame time.
     LARGE_INTEGER t;
     QueryPerformanceCounter(&t);

--- a/SpectatorView/Compositor/CompositorDLL/ElgatoSampleCallback.h
+++ b/SpectatorView/Compositor/CompositorDLL/ElgatoSampleCallback.h
@@ -60,6 +60,10 @@ public:
     }
 
     bool IsVideoFrameReady();
+    bool IsEnabled()
+    {
+        return isEnabled;
+    }
 
 private:
     ULONG m_cRef = 0;
@@ -75,5 +79,6 @@ private:
 
     CRITICAL_SECTION frameAccessCriticalSection;
     bool isVideoFrameReady = false;
+    bool isEnabled = false;
 };
 

--- a/SpectatorView/Compositor/SharedHeaders/CompositorShared.h
+++ b/SpectatorView/Compositor/SharedHeaders/CompositorShared.h
@@ -20,13 +20,15 @@
 
 // FrameProvider type - Exactly 1 of these should be true:
 //TODO: Set this to true if using a BlackMagic DeckLink capture card.
-#define USE_DECKLINK   TRUE
+#define USE_DECKLINK            TRUE
+//TODO: Set this to true if using a USB 3 external BlackMagic Shuttle capture card.
+#define USE_DECKLINK_SHUTTLE    FALSE
 //TODO: Set this to true if using an Elgato capture card.
-#define USE_ELGATO     FALSE
+#define USE_ELGATO              FALSE
 //TODO: Set this to true if using OpenCV to get frames from a camera or capture card.
-#define USE_OPENCV     FALSE
+#define USE_OPENCV              FALSE
 
-static_assert((USE_ELGATO + USE_DECKLINK + USE_OPENCV == 1),
+static_assert((USE_ELGATO + USE_DECKLINK + USE_DECKLINK_SHUTTLE + USE_OPENCV == 1),
     "Exactly 1 FrameProvider must be set");
 
 // Audio

--- a/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/Scripts/SpectatorViewManager.cs
+++ b/SpectatorView/Samples/SharedHolograms/Assets/Addons/HolographicCameraRig/Scripts/SpectatorViewManager.cs
@@ -279,10 +279,8 @@ namespace SpectatorView
             {
                 frameProviderInitialized = InitializeFrameProvider();
             }
-            else if (frameProviderInitialized)
-            {
-                UpdateCompositor();
-            }
+            
+            UpdateCompositor();
 #endif
 
 #region network state


### PR DESCRIPTION
Update video recording and frameprovider logic to record frames when not receiving valid color frames.
Update decklink frameprovider to remove frame flickering when not receiving valid color frames.
Add decklink shuttle frameprovider to special-case decklink frameprovider for the USB3 frame rate limitations.
Update sln's to open in VS 2017 when using the Visual Studio Version Selector.

https://github.com/Microsoft/HoloLensCompanionKit/issues/166
https://github.com/Microsoft/HoloLensCompanionKit/issues/160
https://github.com/Microsoft/HoloLensCompanionKit/issues/162