### PR TITLE
Update CalibrationApp.cpp

### DIFF
--- a/SpectatorView/Calibration/Calibration/CalibrationApp.cpp
+++ b/SpectatorView/Calibration/Calibration/CalibrationApp.cpp
@@ -99,6 +99,9 @@ void CalibrationApp::Initialize(HWND window, int width, int height)
 #if USE_DECKLINK
     frameProvider = new DeckLinkManager(true, true);
 #endif
+#if USE_DECKLINK_SHUTTLE
+    frameProvider = new DeckLinkManager(true, true);
+#endif
 #if USE_OPENCV
     frameProvider = new OpenCVFrameProvider(false);
 #endif


### PR DESCRIPTION
added frameProvider initialization for USE_DECKLINK_SHUTTLE option.

If you use the USE_DECKLINK_SHUTTLE option in SpectatorView/Compositor/SharedHeaders/CompositorShared.h, then frameProvider is never initialized and crashes the program. 