### PR TITLE
Update CalibrationApp.cpp

### DIFF
--- a/SpectatorView/Calibration/Calibration/CalibrationApp.cpp
+++ b/SpectatorView/Calibration/Calibration/CalibrationApp.cpp
@@ -96,7 +96,7 @@ void CalibrationApp::Initialize(HWND window, int width, int height)
 #if USE_ELGATO
     frameProvider = new ElgatoFrameProvider(true);
 #endif
-#if USE_DECKLINK
+#if USE_DECKLINK || USE_DECKLINK_SHUTTLE
     frameProvider = new DeckLinkManager(true, true);
 #endif
 #if USE_OPENCV


### PR DESCRIPTION
added frameProvider initialization for USE_DECKLINK_SHUTTLE option.

Before, if you used the USE_DECKLINK_SHUTTLE option in SpectatorView/Compositor/SharedHeaders/CompositorShared.h, then frameProvider was never initialized and crashed the program. 